### PR TITLE
Fixes for a few typos

### DIFF
--- a/doc/fapolicyd.8
+++ b/doc/fapolicyd.8
@@ -6,7 +6,7 @@ fapolicyd \- File Access Policy Daemon
 .SH DESCRIPTION
 \fBfapolicyd\fP is a userspace daemon that determines access rights to files based on attributes of the process and file. It can be used to either blacklist or whitelist processes or file access.
 
-Configuring \fBfapolicyd\fP is done with the files in \fI/etc/fapolicyd/\fP. There are two files, 
+Configuring \fBfapolicyd\fP is done with the files in \fI/etc/fapolicyd/\fP. There are two files,
 .B fapolicyd.rules
 and
 .B fapolicyd.mounts
@@ -35,7 +35,7 @@ run as a particular user rather than root. This may either be numeric or a user 
 run using a particular group rather than root. This may either be numeric or a user name from the passwd database.
 .TP
 .B \-\-no-details
-when fapolicyd ends, it dumps a usage report with vaious statistics that meay be useful for tuning performeance. It can also detail which processes it knew about and files being accessed by them. This can be useful for foresics investigations. In some settings, this may not be desirable as the file names may be sensitive. Using this option removes process and file names leaving only the statistics. The default without giving this option is to generate a full report.
+when fapolicyd ends, it dumps a usage report with various statistics that may be useful for tuning performance. It can also detail which processes it knew about and files being accessed by them. This can be useful for forensics investigations. In some settings, this may not be desirable as the file names may be sensitive. Using this option removes process and file names leaving only the statistics. The default without giving this option is to generate a full report.
 .SH SIGNALS
 .TP
 SIGTERM

--- a/doc/fapolicyd.rules.5
+++ b/doc/fapolicyd.rules.5
@@ -78,7 +78,7 @@ This option will match against the device that the executable resides on. To use
 .RE
 
 .SS Object
-The object is the file that the subject is interacting with. The fields in the rule that describe the obbject are written in a name=value format. There can be one or more object fields. Each field is and'ed with others to decide if a rule triggers. The name can be any of the following:
+The object is the file that the subject is interacting with. The fields in the rule that describe the object are written in a name=value format. There can be one or more object fields. Each field is and'ed with others to decide if a rule triggers. The name can be any of the following:
 
 .RS
 .TP 12


### PR DESCRIPTION
Fixes for a few typos in manpages:

vaious/various
meay/may
performeance/performance 
foresics/forensics
obbject/object

Apologies, I should have bundled all corrections together.