### PR TITLE
Handle long paths by hashing it (lmdb has 511 byte limit).

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -56,7 +56,7 @@
 static MDB_env *env;
 static MDB_dbi dbi;
 static int dbi_init = 0;
-static unsigned MDB_MAXKEYSIZE;
+static unsigned MDB_maxkeysize;
 const char *data_dir = "/var/lib/fapolicyd";
 const char *db = "trust.db";
 static int lib_symlink=0, lib64_symlink=0, bin_symlink=0, sbin_symlink=0;
@@ -146,7 +146,7 @@ static int init_db(struct daemon_conf *config)
 	if (rc)
 		return 5;
 
-	MDB_MAXKEYSIZE = mdb_env_get_maxkeysize(env);
+	MDB_maxkeysize = mdb_env_get_maxkeysize(env);
 
 	lib_symlink = is_link("/lib");
 	lib64_symlink = is_link("/lib64");
@@ -208,7 +208,7 @@ static char *path_to_hash(const char *path, const size_t path_len)
 	digest = malloc((2 * len) + 1);
 	if (digest == NULL) {
 		gcry_md_close(h);
-		return NULL;
+		return digest;
 	}
 
 	bytes2hex(digest, hptr, len);
@@ -239,7 +239,7 @@ static int write_db(const char *index, const char *data)
 	}
 
 	len = strlen(index);
-	if (len > MDB_MAXKEYSIZE) { /* key size is greater than LMDB key limit */
+	if (len > MDB_maxkeysize) {
 		hash = path_to_hash(index, len);
 		if (hash == NULL)
 			return 5;
@@ -263,7 +263,7 @@ static int write_db(const char *index, const char *data)
 		return 4;
 	}
 
-	if (len > MDB_MAXKEYSIZE) /* key size is greater than LMDB key limit */
+	if (len > MDB_maxkeysize)
 		free(hash);
 
 	return 0;
@@ -347,7 +347,7 @@ static char *lt_read_db(const char *index, int only_check_key)
 		return NULL;
 
 	len = strlen(index);
-	if (len > MDB_MAXKEYSIZE) { /* key size is greater than LMDB key limit */
+	if (len > MDB_maxkeysize) {
 		hash = path_to_hash(index, len);
 		if (hash == NULL)
 			return NULL;
@@ -366,7 +366,7 @@ static char *lt_read_db(const char *index, int only_check_key)
 		return NULL;
 	}
 
-	if (len > MDB_MAXKEYSIZE) /* key size is greater than LMDB key limit */
+	if (len > MDB_maxkeysize)
 		free(hash);
 
 	// Failure means NULL was returned. Need to return a non-null value

--- a/src/file.c
+++ b/src/file.c
@@ -274,7 +274,7 @@ char *get_file_type_from_fd(int fd, size_t blen, char *buf)
 }
 
 // This function converts byte array into asciie hex
-static char *bytes2hex(char *final, const char *buf, unsigned int size)
+char *bytes2hex(char *final, const char *buf, unsigned int size)
 {
 	unsigned int i;
 	char *ptr = final;

--- a/src/file.h
+++ b/src/file.h
@@ -47,6 +47,7 @@ char *get_file_from_fd(int fd, pid_t pid, size_t blen, char *buf);
 char *get_device_from_stat(unsigned int device, size_t blen, char *buf);
 char *get_file_type_from_fd(int fd, size_t blen, char *buf);
 int  check_packaged_from_file(const char *filename);
+char *bytes2hex(char *final, const char *buf, unsigned int size);
 char *get_hash_from_fd(int fd);
 uint32_t gather_elf(int fd, off_t size);
 


### PR DESCRIPTION
MDB_MAXKEYSIZE is set to 511 bytes. 
Store a file by path if the length is less than 490. If the previous condition is false, we convert it to hash using sha256. The very first character of the string indicates:

- "/" path
- "some number"  hash