### PR TITLE
Subject cache contains trust information

### DIFF
--- a/src/subject-attr.c
+++ b/src/subject-attr.c
@@ -20,6 +20,7 @@
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>
+ *   Radovan Sroka <rsroka@redhat.com>
  */
 
 #include "config.h"
@@ -39,6 +40,7 @@ static const nv_t table[] = {
 {	EXE_DIR,    "exe_dir"	},
 {	EXE_TYPE,   "exe_type"	},
 {	EXE_DEVICE, "exe_device" },
+{	SUBJ_TRUST, "subj_trust" },
 };
 
 #define MAX_SUBJECTS (sizeof(table)/sizeof(table[0]))

--- a/src/subject-attr.h
+++ b/src/subject-attr.h
@@ -29,7 +29,7 @@
 #include "nv.h"
 
 // Top is numbers, bottom is strings
-typedef enum { ALL_SUBJ = SUBJ_START, AUID, UID, SESSIONID, PID, PATTERN,
+typedef enum { ALL_SUBJ = SUBJ_START, AUID, UID, SESSIONID, PID, PATTERN, SUBJ_TRUST,
 	COMM, EXE, EXE_DIR, EXE_TYPE, EXE_DEVICE } subject_type_t;
 
 #define SUBJ_END EXE_DEVICE


### PR DESCRIPTION
Subject cache "remember" whether subject itself was/is trusted.

I hope this should help with performance. 
I will try to apply this to object cache but in some other PR.