### PR TITLE
Modify rule grammar

### DIFF
--- a/doc/fapolicyd.rules.5
+++ b/doc/fapolicyd.rules.5
@@ -1,11 +1,11 @@
-.TH FAPOLICYD.RULES: "7" "July 2019" "Red Hat" "System Administration Utilities"
+.TH FAPOLICYD.RULES: "7" "Oct 2019" "Red Hat" "System Administration Utilities"
 .SH NAME
 fapolicyd.rules \- fapolicyd rules to determine access rights
 .SH DESCRIPTION
 \fBfapolicyd.rules\fP is a file that contains the rules that \fBfapolicyd\fP uses to make decisions about access rights. The rules follow a simple format of:
 
 .nf
-.B decision subject object
+.B decision perm subject object
 .fi
 
 They are evaluated from top to bottom with the first rule to match being used
@@ -15,6 +15,11 @@ for the access control decision.
 The decision is either
 .IR allow ", " deny ", " allow_audit ", or " deny_audit ".
 If the rule triggers, this is the access decision that fapolicyd will tell the kernel. If the decision is one of the audit variety, then the decision will trigger a FANOTIFY audit event with all relevant information.
+
+.SS Perm
+Perm describes what kind permission is being asked for. The permission is either
+.IR open " or "execute ".
+If none is given, the open is assumed.
 
 .SS Subject
 The subject is the process that is performing actions on system resources. The fields in the rule that describe the subject are written in a name=value format.i There can be one or more subject fields. Each field is and'ed with others to decide if a rule triggers. The name can be any of the following:
@@ -35,6 +40,9 @@ This is the numeric session id that the audit system assigns to users when they 
 .TP
 .B pid
 This is the numeric process id that a program has.
+.TP
+.B subj_trust
+This is a boolean describing whether it is required for the subject to be in the trust database or not. A value of 1 means its required while 0 means its not.
 .TP
 .B comm
 This is the shortened command name. When an interpreter starts a program, it usually renames the program to the script rather than the interpreter.
@@ -62,7 +70,9 @@ The \fIexecdirs\fP option will match against the following list of directories:
 The \fIexecdirs\fP option will match against the same list as \fIexecdirs\fP but also includes /etc/.
 .TP 12
 .B untrusted
-The \fIuntrusted\fP option will look up the current executable's full path in the rpm database to see if the executable is known to the system. The rule will trigger if the file in question is not packaged.
+The \fIuntrusted\fP option will look up the current executable's full path in the rpm database to see if the executable is known to the system. The rule will trigger if the file in question is not in the trust database. This option is
+.B deprecated
+in favor of using obj_trust with execute permission when writing rules.
 .RE
 .TP
 .B exe_type
@@ -117,6 +127,9 @@ This option will match against the device that the file being accessed resides o
 .TP
 .B ftype
 This option matches against the mime type of the file being accessed. See \fBexe_type\fP for more information on determining the mime type.
+.TP
+.B obj_trust
+This is a boolean describing whether it is required for the object to be in the trust database or not. A value of 1 means its required while 0 means its not.
 .TP
 .B sha256hash
 This option matches against the sha256 hash of the file being accessed. The hash in the rules should be all lowercase letters and do NOT start with 0x. Lowercase is the default output of sha256sum.

--- a/init/fapolicyd.rules
+++ b/init/fapolicyd.rules
@@ -1,9 +1,9 @@
 # This is some sample rules that demonstrate some of the capabilities
-# of the fapolicyd. This is written as a blacklist. If you wanted a
-# whitelist, then you would end with deny all all. But be very careful
-# with that and run in permissive for a while to confirm. Also, the
-# versions of python and the update utilities may need adjusting for
-# your distribution.
+# of the fapolicyd. The way that it works is that for each kind of
+# executable you may have, you carve out what is acceptable (the whitelist)
+# and then deny anything else of that type. The rules end with an allow
+# anything to prevent unintended blockag to things like media files, documents,
+# or anything else applications access that is not a computer langauge.
 
 # Prevent execution by ld.so
 deny_audit pattern=ld_so all
@@ -13,31 +13,23 @@ deny_audit pattern=ld_so all
 allow exe=/usr/bin/rpm all
 allow exe=%python3_path% comm=dnf all
 
-# Don't allow untrusted executables
-deny_audit exe_dir=execdirs exe=untrusted all
-
-# Only allow system ELF Applications - note: depends on above check
-# for untrusted executables.
-allow all dir=execdirs ftype=application/x-executable
-allow all dir=execdirs ftype=application/x-pie-executable
-deny_audit all ftype=application/x-executable
-deny_audit all ftype=application/x-pie-executable
-
-# If you have a LD_LIBRARY_PATH, you may need to allow those here
-# allow all dir=/usr/local/cuda/lib64 ftype=application/x-sharedlib
-
-# Only allow system ELF libs
-allow all dir=execdirs ftype=application/x-sharedlib
+# Only allow known ELF libs - this is ahead of executable because typical
+# executable is linked with a dozen or more libraries.
+allow all ftype=application/x-sharedlib obj_trust=1
 deny_audit all ftype=application/x-sharedlib
+
+# Only allow known ELF Applications
+allow perm=execute all ftype=application/x-pie-executable obj_trust=1
+allow perm=execute all ftype=application/x-executable obj_trust=1
+deny_audit perm=execute all ftype=application/x-pie-executable
+deny_audit perm=execute all ftype=application/x-executable
 
 # Only allow system python executables and libs
 # File type by: file --mime-type /path-to-file
-allow all dir=execdirs ftype=text/x-python
-allow exe=%python3_path% dir=execdirs ftype=text/x-python
-allow exe=%python3_path% dir=execdirs ftype=application/octet-stream
-allow exe=%python2_path% dir=execdirs ftype=text/x-python
-allow exe=%python2_path% dir=execdirs ftype=application/octet-stream
-deny_audit  all ftype=text/x-python
+allow all ftype=text/x-python obj_trust=1 dir=execdirs
+allow exe=%python3_path% ftype=application/octet-stream obj_trust=1 dir=execdirs
+allow exe=%python2_path% ftype=application/octet-stream obj_trust=1 dir=execdirs
+deny_audit all ftype=text/x-python
 #deny_audit all ftype=application/octet-stream path=*.pyc
 
 #
@@ -50,21 +42,21 @@ deny_audit  all ftype=text/x-python
 deny_audit exe=/usr/bin/perl all
 
 # Perl
-#allow all dir=execdirs ftype=text/x-perl
+#allow all dir=execdirs ftype=text/x-perl obj_trust=1
 #deny_audit all ftype=text/x-perl
 
 # Block all PHP
 deny_audit exe=/usr/bin/php all
 
 # PHP
-#allow all dir=execdirs ftype=text/x-php
+#allow all dir=execdirs ftype=text/x-php obj_trust=1
 #deny_audit all ftype=text/x-php
 
 # Block all Ruby
 deny_audit exe=/usr/bin/ruby all
 
 # Ruby
-#allow all dir=execdirs ftype=text/x-ruby
+#allow all dir=execdirs ftype=text/x-ruby obj_trust=1
 #deny_audit  all ftype=text/x-ruby
 
 # Data exfiltration

--- a/src/object-attr.c
+++ b/src/object-attr.c
@@ -34,7 +34,7 @@ static const nv_t table[] = {
 {	ODIR, 		"dir" },
 {	DEVICE,		"device" },
 {	FTYPE,		"ftype" },
-/*{	OBJ_TRUST,	"obj_trust"},*/
+{	OBJ_TRUST,	"obj_trust"},
 {	SHA256HASH,	"sha256hash" },
 {	FMODE,		"mode" },
 };

--- a/src/rules.h
+++ b/src/rules.h
@@ -32,10 +32,13 @@
 
 #define MAX_FIELDS 8
 
+typedef enum { OPEN_ACC, EXEC_ACC } access_t;
+
 /* This is one node of the linked list. Any data elements that are per
  * rule goes here. */
 typedef struct _lnode{
   decision_t d;
+  access_t a;
   unsigned int num;
   unsigned int s_count;
   unsigned int o_count;

--- a/src/subject-attr.c
+++ b/src/subject-attr.c
@@ -35,7 +35,7 @@ static const nv_t table[] = {
 {	SESSIONID,  "sessionid"	},
 {	PID,        "pid"	},
 {	PATTERN,    "pattern"	},
-/*{	SUBJ_TRUST, "subj_trust" },*/
+{	SUBJ_TRUST, "subj_trust" },
 {	COMM,       "comm"	},
 {	EXE,        "exe"	},
 {	EXE_DIR,    "exe_dir"	},


### PR DESCRIPTION
This patch creates a new rule grammar that adds a new permission request
field, perm, to the rules. The perm field may be omitted for backwards
compatibility which will assume the request is for opening a file. This
patch also exposes the trust database though subject and object fields.
These are subj_trust and obj_trust respectively. These may be either a
0 or 1 to inidicate that the item being in the trust database is or is not
required.