### PR TITLE
Switchable trust back-ends

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -22,5 +22,9 @@
 
 EXTRA_DIST = $(man_MANS)
 
-man_MANS = fapolicyd.8 fapolicyd-cli.1 fapolicyd.rules.5 fapolicyd.conf.5
-
+man_MANS = \
+	fapolicyd.8 \
+	fapolicyd-cli.1 \
+	fapolicyd.rules.5 \
+	fapolicyd.trust.5 \
+	fapolicyd.conf.5

--- a/doc/fapolicyd.conf.5
+++ b/doc/fapolicyd.conf.5
@@ -50,6 +50,11 @@ This option controls how many entries the object cache holds. You want the size 
 .I watch_fs
 This is a comma separated list of file systems that should be watched for access permission. No attempt is made to validate the file systems names. They should exactly match the name presented in the first column of /proc/mounts. If this is not configured, it will default to watching ext4, xfs, and tmpfs.
 
+.TP
+.I trust
+This is a comma separated list of trust back-ends. If this is not configured, file is default. Fapolicyd supports file back-end that reads content of /etc/fapolicyd/fapolicyd.trust and use it as a list of trusted files. The second option is rpmdb backend that generates list of trusted files from rpmdb.
+
+
 .SH "SEE ALSO"
 .BR fapolicyd (8),
 .BR fapolicyd-cli (1)

--- a/doc/fapolicyd.trust.5
+++ b/doc/fapolicyd.trust.5
@@ -1,0 +1,31 @@
+.TH FAPOLICYD.TRUST: "13" "January 2020" "Red Hat" "System Administration Utilities"
+.SH NAME
+fapolicyd.trust \- fapolicyd's file of trust
+.SH DESCRIPTION
+The file
+.I /etc/fapolicyd/fapolicyd.trust
+contains list of trusted files/binaries for the application whitelisting daemon. You may add comments to the file by starting the line with a '#' character.
+Each line has to contain three columns and space is a valid separator. The first column contains full path to the file, the second is size of the file in bytes
+and the third is valid sha256 hash.
+
+.SH EXAMPLE
+.PP
+.EX
+[root@Desktop ~]# cat /etc/fapolicyd/fapolicyd.trust
+/home/user/my-ls 157984 61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87
+/home/user/my-ls2 5555 61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87
+.EE
+
+.SH FILES
+.B /etc/fapolicyd/fapolicyd.trust
+- list of trusted files/binaries
+
+.SH "SEE ALSO"
+.BR fapolicyd (8),
+.BR fapolicyd-cli (1)
+.BR fapolicy.rules (5)
+and
+.BR fapolicy.conf (5).
+
+.SH AUTHOR
+Radovan Sroka

--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -66,6 +66,7 @@ getent passwd %{name} >/dev/null || useradd -r -M -d %{_localstatedir}/lib/%{nam
 %attr(750,root,%{name}) %dir %{_sysconfdir}/%{name}
 %config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/%{name}.rules
 %config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/%{name}.conf
+%config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/%{name}.trust
 %attr(644,root,root) %{_unitdir}/%{name}.service
 %attr(644,root,root) %{_tmpfilesdir}/%{name}.conf
 %attr(755,root,root) %{_sbindir}/%{name}

--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -1,5 +1,16 @@
-EXTRA_DIST = fapolicyd.rules  fapolicyd.service fapolicyd.conf fapolicyd-tmpfiles.conf
+EXTRA_DIST = \
+	fapolicyd.rules \
+	fapolicyd.service \
+	fapolicyd.conf \
+	fapolicyd.trust \
+	fapolicyd-tmpfiles.conf
+
 fapolicyddir = $(sysconfdir)/fapolicyd
-dist_fapolicyd_DATA = fapolicyd.rules fapolicyd.conf
+
+dist_fapolicyd_DATA = \
+	fapolicyd.rules \
+	fapolicyd.conf \
+	fapolicyd.trust
+
 systemdservicedir = $(systemdsystemunitdir)
 dist_systemdservice_DATA = fapolicyd.service

--- a/init/fapolicyd.conf
+++ b/init/fapolicyd.conf
@@ -14,3 +14,4 @@ db_max_size = 250
 subj_cache_size = 1024
 obj_cache_size = 6144
 watch_fs = ext2,ext3,ext4,tmpfs,xfs,vfat,iso9660
+trust = rpmdb,files

--- a/init/fapolicyd.trust
+++ b/init/fapolicyd.trust
@@ -1,0 +1,4 @@
+# This is a sample file that contains list of trusted files
+
+#  FULL PATH        SIZE                             SHA256
+# /home/user/my-ls 157984 61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,14 +17,20 @@ fapolicyd_cli_LDFLAGS = $(fapolicyd_LDFLAGS)
 libfapolicyd_la_SOURCES = \
 	library/avl.c \
 	library/avl.h \
+	library/backend-manager.c \
+	library/backend-manager.h \
 	library/conf.h \
 	library/database.c \
 	library/database.h \
 	library/event.c \
 	library/event.h \
 	library/fapolicyd-defs.h \
+	library/fapolicyd-backend.h \
 	library/file.c \
 	library/file.h \
+	library/file-backend.c \
+	library/llist.c \
+	library/llist.h \
 	library/lru.c \
 	library/lru.h \
 	library/message.c \
@@ -40,14 +46,13 @@ libfapolicyd_la_SOURCES = \
 	library/process.h \
 	library/queue.c \
 	library/queue.h \
+	library/rpm-backend.c \
 	library/rules.c \
 	library/rules.h \
 	library/subject-attr.c \
 	library/subject-attr.h \
 	library/subject.c \
-	library/subject.h \
-	library/temporary_db.c \
-	library/temporary_db.h
+	library/subject.h
 
 libfapolicyd_la_CFLAGS = $(fapolicyd_CFLAGS)
 libfapolicyd_la_LDFLAGS = $(fapolicyd_LDFLAGS) -lpthread

--- a/src/daemon/daemon-config.c
+++ b/src/daemon/daemon-config.c
@@ -20,6 +20,7 @@
  *
  * Authors:
  *   Steve Grubb <sgrubb@redhat.com>
+ *   Radovan Sroka <rsroka@redhat.com>
  *
  */
 
@@ -77,6 +78,8 @@ static int do_stat_report_parser(const struct nv_pair *nv, int line,
 		conf_t *config);
 static int watch_fs_parser(const struct nv_pair *nv, int line,
 		conf_t *config);
+static int trust_parser(const struct nv_pair *nv, int line,
+			   conf_t *config);
 
 static const struct kw_pair keywords[] =
 {
@@ -91,6 +94,7 @@ static const struct kw_pair keywords[] =
   {"obj_cache_size",	obj_cache_size_parser },
   {"do_stat_report",	do_stat_report_parser },
   {"watch_fs",		watch_fs_parser },
+  {"trust",		trust_parser },
   { NULL,		NULL }
 };
 
@@ -110,6 +114,7 @@ static void clear_daemon_config(conf_t *config)
 	config->subj_cache_size = 1024;
 	config->obj_cache_size = 4096;
 	config->watch_fs = strdup("ext4,xfs,tmpfs");
+	config->trust = strdup("file");
 }
 
 int load_daemon_config(conf_t *config)
@@ -314,6 +319,7 @@ void free_daemon_config(conf_t *config)
 {
 //	free((void*)config->file);
 	free((void*)config->watch_fs);
+	free((void*)config->trust);
 }
 
 static int unsigned_int_parser(unsigned *i, const char *str, int line)
@@ -495,3 +501,12 @@ static int watch_fs_parser(const struct nv_pair *nv, int line,
 	return 1;
 }
 
+static int trust_parser(const struct nv_pair *nv, int line,
+			   conf_t *config)
+{
+	free((void *)config->trust);
+	config->trust = strdup(nv->value);
+	if (config->trust)
+		return 0;
+	return 1;
+}

--- a/src/daemon/fapolicyd.c
+++ b/src/daemon/fapolicyd.c
@@ -535,7 +535,13 @@ int main(int argc, char *argv[])
 	init_event_system(&config);
 
 	// Init the database
-	init_database(&config);
+	if (init_database(&config)) {
+		destroy_event_system();
+		destroy_config();
+		destroy_fs_list();
+		free_daemon_config(&config);
+		exit(1);
+	}
 
 	// Init the file test libraries
 	file_init();

--- a/src/library/backend-manager.c
+++ b/src/library/backend-manager.c
@@ -1,0 +1,153 @@
+/*
+ * backend-manager.c - backend management
+ * Copyright (c) 2020 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Radovan Sroka <rsroka@redhat.com>
+ */
+
+#include "config.h"
+#include <ctype.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "conf.h"
+#include "message.h"
+#include "backend-manager.h"
+#include "fapolicyd-backend.h"
+
+extern backend file_backend;
+extern backend rpm_backend;
+
+static backend* compiled[] =
+{
+	&file_backend,
+	&rpm_backend,
+	NULL,
+};
+
+static backend_entry* backends = NULL;
+
+static int backend_push(const char* name)
+{
+	long index = -1;
+	for (long i = 0 ; compiled[i] != NULL; i++) {
+		if (strcmp(name, compiled[i]->name) == 0) {
+			index = i;
+			break;
+		}
+	}
+
+	if (index == -1) {
+		msg(LOG_ERR, "%s backend not supported, aborting!", name);
+		return 1;
+	} else {
+		backend_entry * tmp = (backend_entry*)
+				malloc(sizeof(backend_entry));
+
+		if (!tmp) {
+			msg(LOG_ERR, "cannot allocate %s backend", name);
+			return 1;
+		}
+
+		tmp->backend = compiled[index];
+		tmp->next = NULL;
+
+		if (!backends)
+			backends = tmp;
+		else
+			backends->next = tmp;
+	}
+	return 0;
+}
+
+static int backend_destroy(void)
+{
+	backend_entry * be = backend_get_first();
+	backend_entry * tmp = NULL;
+
+	while ( be != NULL ) {
+		tmp = be;
+		be = be->next;
+		free(tmp);
+	}
+	backends = NULL;
+	return 0;
+}
+
+
+static int backend_create(const char * trust_list)
+{
+
+	char *ptr, *saved, *tmp = strdup(trust_list);
+
+	if (!tmp) return 1;
+
+	ptr = strtok_r(tmp, ",", &saved);
+	while (ptr) {
+		if (backend_push(ptr)) {
+			free(tmp);
+			return 1;
+		}
+		ptr = strtok_r(NULL, ",", &saved);
+	}
+	free(tmp);
+	return 0;
+}
+
+
+int backend_init(const conf_t * conf)
+{
+
+	if (backend_create(conf->trust)) return 1;
+
+	for (backend_entry * be = backend_get_first();
+			be != NULL;
+			be = be->next) {
+		if (be->backend->init()) return 1;
+	}
+	return 0;
+}
+
+int backend_load(void)
+{
+	for (backend_entry * be = backend_get_first() ;
+			be != NULL;
+			be = be->next) {
+		if (be->backend->load()) return 1;
+	}
+	return 0;
+}
+
+void backend_close(void)
+{
+	for (backend_entry * be = backend_get_first();
+			be != NULL;
+			be = be->next) {
+		be->backend->close();
+	}
+	backend_destroy();
+}
+
+backend_entry* backend_get_first(void)
+{
+	return backends;
+}

--- a/src/library/backend-manager.h
+++ b/src/library/backend-manager.h
@@ -1,6 +1,6 @@
 /*
- * temporary_db.h - Header file for linked list
- * Copyright (c) 2018 Red Hat Inc., Durham, North Carolina.
+ * backend-manager.h - Header file for backend manager
+ * Copyright (c) 2020 Red Hat Inc.
  * All Rights Reserved.
  *
  * This software may be freely redistributed and/or modified under the
@@ -22,26 +22,23 @@
  *   Radovan Sroka <rsroka@redhat.com>
  */
 
-#ifndef TEMPORARY_DB
-#define TEMPORARY_DB
+#ifndef BACKEND_MANAGER_H
+#define BACKEND_MANAGER_H
 
-#include "config.h"
+#include <stdbool.h>
 
-typedef struct db_item {
-    const char* index;
-    const char* data;
-    struct db_item* next;
-} db_item_t;
+#include "conf.h"
+#include "fapolicyd-backend.h"
 
-typedef struct db_list_header {
-    long count;
-    struct db_item* first;
-    struct db_item* last;
-} db_list_t;
+typedef struct _backend_entry {
+	backend * backend;
+	struct _backend_entry * next;
+} backend_entry;
 
-void init_db_list(void);
-db_item_t* get_first_from_db_list(void);
-int append_db_list(const char * index, const char * data);
-void empty_db_list(void);
+
+int backend_init(const conf_t * conf);
+int backend_load(void);
+void backend_close(void);
+backend_entry* backend_get_first(void);
 
 #endif

--- a/src/library/conf.h
+++ b/src/library/conf.h
@@ -1,4 +1,4 @@
-/* conf.h --
+/* conf.h configuration structure
  * Copyright 2018-19 Red Hat Inc., Durham, North Carolina.
  * All Rights Reserved.
  *
@@ -39,6 +39,7 @@ typedef struct conf
 	unsigned int subj_cache_size;
 	unsigned int obj_cache_size;
 	const char *watch_fs;
+	const char *trust;
 } conf_t;
 
 #endif

--- a/src/library/fapolicyd-backend.h
+++ b/src/library/fapolicyd-backend.h
@@ -1,0 +1,43 @@
+
+/*
+ * fapolicyd-backend.h - Header file for database backend interface
+ * Copyright (c) 2020 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Radovan Sroka <rsroka@redhat.com>
+ */
+
+#ifndef FAPOLICYD_BACKEND_HEADER
+#define FAPOLICYD_BACKEND_HEADER
+
+#include "llist.h"
+
+// verified, size, sha
+#define DATA_FORMAT "%i %lu %s"
+
+typedef struct _backend
+{
+	const char * name;
+	int (*init)(void);
+	int (*load)(void);
+	int (*close)(void);
+	list_t list;
+} backend;
+
+#endif

--- a/src/library/file-backend.c
+++ b/src/library/file-backend.c
@@ -1,0 +1,173 @@
+/*
+ * file-backend.c - file backend
+ * Copyright (c) 2020 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Radovan Sroka <rsroka@redhat.com>
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include "message.h"
+
+#include "fapolicyd-backend.h"
+#include "llist.h"
+
+#define FILE_PATH "/etc/fapolicyd/fapolicyd.trust"
+#define BUFFER_SIZE 4096
+
+static int file_init_backend(void);
+static int file_load_list(void);
+static int file_destroy_backend(void);
+
+backend file_backend =
+{
+	"file",
+	file_init_backend,
+	file_load_list,
+	file_destroy_backend,
+	{ 0, 0, NULL },
+};
+
+
+enum _states {
+	NAME = 0,
+	SIZE,
+	SHA,
+};
+
+#define DELIMITER " "
+
+static int file_load_list(void)
+{
+	char buffer[BUFFER_SIZE];
+	msg(LOG_INFO, "Loading file backend");
+
+	list_empty(&file_backend.list);
+	memset(buffer, 0, BUFFER_SIZE);
+
+	FILE *file = fopen(FILE_PATH, "r");
+	if (!file) {
+		msg(LOG_ERR, "Cannot open %s", FILE_PATH);
+		return 1;
+	}
+
+	long line = 1;
+	while(fgets(buffer, BUFFER_SIZE, file)) {
+
+		char *ptr, *saved;
+		int state = NAME;
+
+		char * name = NULL;
+		char * size = NULL;
+		char * sha = NULL;
+
+		if(iscntrl(buffer[0]) || buffer[0] == '#') {
+			memset(buffer, 0, BUFFER_SIZE);
+			continue;
+		}
+
+		ptr = strtok_r(buffer, DELIMITER, &saved);
+		while (ptr) {
+			if(strlen(ptr) == 0)
+				continue;
+
+			switch(state) {
+				case NAME:
+					name = ptr;
+					break;
+
+				case SIZE:
+					size = ptr;
+					break;
+
+				case SHA:
+					sha = ptr;
+					break;
+
+				default:
+					fclose(file);
+					msg(	LOG_ERR,
+						"%s:%ld : Too many columns",
+						FILE_PATH,
+						line);
+					return 1;
+			}
+			state++;
+			ptr = strtok_r(NULL, DELIMITER, &saved);
+		}
+
+		char * eptr = NULL;
+		unsigned long sz = strtoul(size, &eptr , 10);
+		if (*eptr != '\0') {
+			msg(	LOG_ERR,
+				"%s:%ld Cannot convert size to number.",
+				FILE_PATH,
+				line);
+			fclose(file);
+			return 1;
+		}
+
+		char *index = NULL;
+		char *data = NULL;
+		int verified = 0;
+
+		// TODO: create proper trim function
+		sha[64] = '\0';
+
+		if (asprintf(	&data,
+				DATA_FORMAT,
+				verified,
+				sz,
+				sha) == -1) {
+			data = NULL;
+		}
+
+		index = strdup(name);
+
+		//msg(LOG_INFO, "GGG: %s, %s", index, data);
+		if (index && data)
+			list_append(&file_backend.list, index, data);
+
+		//free(data);
+		memset(buffer, 0, BUFFER_SIZE);
+		line++;
+	}
+
+	fclose(file);
+	return 0;
+}
+
+
+static int file_init_backend(void)
+{
+	list_init(&file_backend.list);
+	return 0;
+}
+
+static int file_destroy_backend(void)
+{
+	list_empty(&file_backend.list);
+	return 0;
+}

--- a/src/library/llist.c
+++ b/src/library/llist.c
@@ -1,5 +1,5 @@
 /*
- * temporary_db.c - Linked list as a temporary memory storage
+ * llist.c - Linked list as a temporary memory storage
  * for rpm databse data
  * Copyright (c) 2016,2018 Red Hat Inc., Durham, North Carolina.
  * All Rights Reserved.
@@ -28,24 +28,25 @@
 #include <string.h>
 
 #include "message.h"
-#include "temporary_db.h"
+#include "llist.h"
 
-static db_list_t list_header;
-
-void init_db_list() {
-    list_header.count = 0;
-    list_header.first = NULL;
-    list_header.last = NULL;
+void list_init(list_t * list)
+{
+    list->count = 0;
+    list->first = NULL;
+    list->last = NULL;
 }
 
-db_item_t* get_first_from_db_list(void) {
-    return list_header.first;
+list_item_t* list_get_first(list_t * list)
+{
+    return list->first;
 }
 
-int append_db_list(const char * index, const char * data) {
-    db_item_t* item;
+int list_append(list_t * list, const char * index, const char * data)
+{
+    list_item_t* item;
 
-    if ((item = (db_item_t*)malloc(sizeof(db_item_t))) == NULL) {
+    if ((item = (list_item_t*)malloc(sizeof(list_item_t))) == NULL) {
         msg(LOG_ERR, "Malloc failed");
         return 1;
     }
@@ -54,39 +55,41 @@ int append_db_list(const char * index, const char * data) {
     item->data = data;
     item->next = NULL;
 
-    if (list_header.first == NULL) {
-        list_header.first = item;
-        list_header.last = item;
+    if (list->first == NULL) {
+        list->first = item;
+        list->last = item;
     } else {
-        db_item_t* tmp = list_header.last;
-        list_header.last = item;
+        list_item_t* tmp = list->last;
+        list->last = item;
         tmp->next = item;
     }
 
-    list_header.count++;
+    list->count++;
     return 0;
 }
 
-static void destroy_db_item(db_item_t** item) {
+static void list_destroy_item(list_item_t** item)
+{
     free((void*)(*item)->index);
     free((void*)(*item)->data);
     free((*item));
     *item = NULL;
 }
 
-void empty_db_list(void) {
-    if (list_header.first == NULL) {
+void list_empty(list_t * list)
+{
+    if (list->first == NULL) {
         return;
     } else {
-        db_item_t* actual = list_header.first;
-        db_item_t* next = NULL;
+        list_item_t* actual = list->first;
+        list_item_t* next = NULL;
         for (; actual != NULL ; actual = next) {
             next = actual->next;
-            destroy_db_item(&actual);
+            list_destroy_item(&actual);
         }
 
-        list_header.first = NULL;
-        list_header.last = NULL;
-        list_header.count = 0;
+        list->first = NULL;
+        list->last = NULL;
+        list->count = 0;
     }
 }

--- a/src/library/llist.h
+++ b/src/library/llist.h
@@ -1,0 +1,45 @@
+/*
+ * temporary_db.h - Header file for linked list
+ * Copyright (c) 2018 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Radovan Sroka <rsroka@redhat.com>
+ */
+
+#ifndef LLIST_H
+#define LLIST_H
+
+typedef struct item {
+    const void * index;
+    const void * data;
+    struct item * next;
+} list_item_t;
+
+typedef struct list_header {
+    long count;
+    struct item* first;
+    struct item* last;
+} list_t;
+
+void list_init(list_t * list);
+list_item_t* list_get_first(list_t * list);
+int list_append(list_t * list, const char * index, const char * data);
+void list_empty(list_t * list);
+
+#endif

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -1,0 +1,230 @@
+/*
+ * rpm-backend.c - rpm backend
+ * Copyright (c) 2020 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Radovan Sroka <rsroka@redhat.com>
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <sys/types.h>
+#include <rpm/rpmlib.h>
+#include <rpm/rpmts.h>
+#include <rpm/rpmmacro.h>
+#include <rpm/rpmlog.h>
+#include <rpm/rpmdb.h>
+
+#include "message.h"
+
+#include "fapolicyd-backend.h"
+#include "llist.h"
+
+static int rpm_init_backend(void);
+static int rpm_load_list(void);
+static int rpm_destroy_backend(void);
+
+backend rpm_backend =
+{
+	"rpmdb",
+	rpm_init_backend,
+	rpm_load_list,
+	rpm_destroy_backend,
+	/* list initialization */
+	{ 0, 0, NULL },
+};
+
+static rpmts ts = NULL;
+static rpmdbMatchIterator mi = NULL;
+
+static int init_rpm(void)
+{
+	return rpmReadConfigFiles ((const char *)NULL, (const char *)NULL);
+}
+
+static Header h = NULL;
+static int get_next_package_rpm(void)
+{
+	// If this is the first time, create a package iterator
+	if (mi == NULL) {
+		ts = rpmtsCreate();
+		mi = rpmtsInitIterator(ts, RPMDBI_PACKAGES, NULL, 0);
+		if (mi == NULL)
+			return 0;
+	}
+
+	if (h)	// Decrement reference count, and free memory
+		headerFree(h);
+
+	h = rpmdbNextIterator(mi);
+	if (h == NULL)
+		return 0;	// No more packages, done
+
+	// Increment reference count
+	headerLink(h);
+
+	return 1;
+}
+
+static rpmfi fi = NULL;
+static int get_next_file_rpm(void)
+{
+	// If its the first time, make file iterator
+	if (fi == NULL)
+		fi = rpmfiNew(NULL, h, RPMTAG_BASENAMES, RPMFI_KEEPHEADER);
+
+	if (fi) {
+		if (rpmfiNext(fi) == -1) {
+			// No more files, cleanup iterator
+			rpmfiFree(fi);
+			fi = NULL;
+			return 0;
+		}
+        }
+	return 1;
+}
+
+static const char *get_file_name_rpm(void)
+{
+	return strdup(rpmfiFN(fi));
+}
+
+static off_t get_file_size_rpm(void)
+{
+	return rpmfiFSize(fi);
+}
+
+static char *get_sha256_rpm(void)
+{
+	return rpmfiFDigestHex(fi, NULL);
+}
+
+static int is_dir_rpm(void)
+{
+	mode_t mode = rpmfiFMode(fi);
+	if (S_ISDIR(mode))
+		return 1;
+	return 0;
+}
+
+/* We don't want doc files in the database */
+static int is_doc_rpm(void)
+{
+	if (rpmfiFFlags(fi) & (RPMFILE_DOC|RPMFILE_README|
+				RPMFILE_GHOST|RPMFILE_LICENSE|RPMFILE_PUBKEY))
+		return 1;
+	return 0;
+}
+
+/* Config files can have a changed hash. We want them in the db since
+ * they are trusted. */
+static int is_config_rpm(void)
+{
+	if (rpmfiFFlags(fi) &
+		(RPMFILE_CONFIG|RPMFILE_MISSINGOK|RPMFILE_NOREPLACE))
+		return 1;
+	return 0;
+}
+
+static void close_rpm(void)
+{
+	rpmfiFree(fi);
+	fi = NULL;
+	headerFree(h);
+	h = NULL;
+	rpmdbFreeIterator(mi);
+	mi = NULL;
+	rpmtsFree(ts);
+	ts = NULL;
+	rpmFreeCrypto();
+	rpmFreeRpmrc();
+	rpmFreeMacros(NULL);
+	rpmlogClose();
+}
+
+
+static int rpm_load_list(void)
+{
+	int rc;
+
+	// empty list before loading
+	list_empty(&rpm_backend.list);
+
+	msg(LOG_INFO, "Loading rpmdb backend");
+	if ((rc = init_rpm())) {
+		msg(LOG_ERR, "init_rpm() failed (%d)", rc);
+		return rc;
+	}
+
+	// Loop across the rpm database
+	while (get_next_package_rpm()) {
+		// Loop across the packages
+		while (get_next_file_rpm()) {
+			// We do not want directories in the database
+			// Multiple packages can own the same directory
+			// and that causes problems in the size info.
+			if (is_dir_rpm())
+				continue;
+
+			// We do not want any documentation in the database
+			if (is_doc_rpm())
+				continue;
+
+			// We do not want any configuration files in database
+			if (is_config_rpm())
+				continue;
+
+			// Get specific file information
+			const char *file_name = get_file_name_rpm();
+			off_t sz = get_file_size_rpm();
+			const char *sha = get_sha256_rpm();
+			char *data;
+			int verified = 0;
+			if (asprintf(	&data,
+					DATA_FORMAT,
+					verified,
+					sz,
+					sha) == -1) {
+				data = NULL;
+			}
+			if (data)
+				list_append(&rpm_backend.list, file_name, data);
+			else {
+				free((void*)file_name);
+			}
+
+			free((void *)sha);
+		}
+	}
+
+	close_rpm();
+	return 0;
+}
+
+static int rpm_init_backend(void)
+{
+	list_init(&rpm_backend.list);
+	return 0;
+}
+
+static int rpm_destroy_backend(void)
+{
+	list_empty(&rpm_backend.list);
+	return 0;
+}


### PR DESCRIPTION
This PR introduces a possibility to set and manage multiple trust back-ends. Admin can choose between two available options which are ```rpmdb``` and ```file``` or use both. Trust back-end can be set in daemon configuration.

The set of back-ends is expandable very easily via interface located in ```src/library/fapolicyd-backend.h```.