### PR TITLE
Fixed threads synchronization

### DIFF
--- a/src/library/event.h
+++ b/src/library/event.h
@@ -42,7 +42,6 @@ typedef struct ev {
 } event_t;
 
 int init_event_system(const conf_t *config);
-int flush_cache(const conf_t *config);
 void destroy_event_system(void);
 int new_event(const struct fanotify_event_metadata *m, event_t *e);
 subject_attr_t *get_subj_attr(event_t *e, subject_type_t t);


### PR DESCRIPTION
Thanks to thread sanitizer and valgrind I've discovered
and fixed these few issues related to thread synchronization.

- update_lock was used before its initialization
- check_trust_database() could read from database even when
  update thread locked resources and it was providing an update
- calling flush_cache() from update thread wasn't good idea
  since the resource owner was decision thread
- update thread now only signals event system that cache should
  be flushed and this is checked within new_event()

Signed-off-by: Radovan Sroka <rsroka@redhat.com>