### PR TITLE
Sync fapolicyd.conf man page trust option with the real default.

### DIFF
--- a/doc/fapolicyd.conf.5
+++ b/doc/fapolicyd.conf.5
@@ -52,7 +52,7 @@ This is a comma separated list of file systems that should be watched for access
 
 .TP
 .B trust
-This is a comma separated list of trust back-ends. If this is not configured, rpmdb is default. Fapolicyd supports \fBfile\fP back-end that reads content of /etc/fapolicyd/fapolicyd.trust and use it as a list of trusted files. The second option is \fBrpmdb\fP backend that generates list of trusted files from rpmdb.
+This is a comma separated list of trust back-ends. If this is not configured, 'rpmdb,file' is default. Fapolicyd supports \fBfile\fP back-end that reads content of /etc/fapolicyd/fapolicyd.trust and use it as a list of trusted files. The second option is \fBrpmdb\fP backend that generates list of trusted files from rpmdb.
 
 .TP
 .B integrity


### PR DESCRIPTION
Signed-off-by: Radovan Sroka <rsroka@redhat.com>