### PR TITLE
Re-implement LD_PRELOAD detection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
 - Allow arbitrarily large group statements
 - Fix logging of object trust
 - Correct denial accounting
+- Add new form of LD_PRELOAD pattern detection
 
 1.0
 - Add file size, IMA, and sha256 based integrity checking

--- a/doc/fapolicyd.rules.5
+++ b/doc/fapolicyd.rules.5
@@ -98,6 +98,9 @@ This matches against any ELF program that is dynamically linked.
 .B ld_so
 This matches against access patterns that indicate that the program is being started directly by the runtime linker.
 .TP
+.B ld_preload
+This matches against access patterns that indicate that the program is being started with either LD_PRELOAD or LD_AUDIT present in the environment. Note that even without this rule, you have protection against LD_PRELOAD of unknown binaries when the rules are written such that trust is used to determine if a library should be opened. In that case, the preloaded library would be denied but the application will still execute. This rule makes it so that even trusted libraries can be denied and the application will not execute.
+.TP
 .B static
 This matches against ELF files that are statically linked.
 .RE

--- a/src/library/process.h
+++ b/src/library/process.h
@@ -38,7 +38,8 @@ typedef enum {	STATE_COLLECTING=0,	// initial state - execute
 		STATE_NOT_ELF,		// not elf, ignore
 		STATE_LD_SO,		// app started by ld.so
 		STATE_STATIC,		// app is static
-		STATE_BAD_ELF		// app is elf but malformed
+		STATE_BAD_ELF,		// app is elf but malformed
+		STATE_LD_PRELOAD	// app has LD_PRELOAD or LD_AUDIT set
 } state_t;
 
 // This is used to determine what kind of elf file we are looking at.
@@ -77,5 +78,6 @@ char *get_type_from_pid(pid_t pid, size_t blen, char *buf);
 uid_t get_program_auid_from_pid(pid_t pid);
 int get_program_sessionid_from_pid(pid_t pid);
 uid_t get_program_uid_from_pid(pid_t pid);
+int check_environ_from_pid(pid_t pid);
 
 #endif

--- a/src/library/rules.c
+++ b/src/library/rules.c
@@ -55,6 +55,8 @@
 #define PATTERN_LD_SO_VAL 1
 #define PATTERN_STATIC_STR "static"
 #define PATTERN_STATIC_VAL 2
+#define PATTERN_LD_PRELOAD_STR "ld_preload"
+#define PATTERN_LD_PRELOAD_VAL 3
 
 int rules_create(llist *l)
 {
@@ -396,6 +398,8 @@ static int assign_subject(lnode *n, int type, const char *ptr2, int lineno)
 			n->s[i].val = PATTERN_LD_SO_VAL;
 		} else if (strcmp(tmp, PATTERN_STATIC_STR) == 0) {
 			n->s[i].val = PATTERN_STATIC_VAL;
+		} else if (strcmp(tmp, PATTERN_LD_PRELOAD_STR) == 0) {
+			n->s[i].val = PATTERN_LD_PRELOAD_VAL;
 		} else {
 			msg(LOG_ERR,
 				"Unknown pattern value %s in line %d",
@@ -1074,6 +1078,13 @@ make_decision:
 				(pinfo->state == STATE_STATIC_PARTIAL) ||
 				(pinfo->state == STATE_STATIC))
 				rc = 1;
+			break;
+		case PATTERN_LD_PRELOAD_VAL: {
+			int env = check_environ_from_pid(pinfo->pid);
+			if (env == 1) {
+				pinfo->state = STATE_LD_PRELOAD;
+				rc = 1;
+			} }
 			break;
 	}
 


### PR DESCRIPTION
This patch adds support to detect LD_PRELOAD and LD_AUDIT usage. It will
prevent execution if either are detected in the application's environment.
This will override any trust qualifications for the library being preloaded.