### PR TITLE
Move metadata fd close call

### DIFF
--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -322,8 +322,8 @@ static void approve_event(const struct fanotify_event_metadata *metadata)
 
 	response.fd = metadata->fd;
 	response.response = FAN_ALLOW;
-	write(fd, &response, sizeof(struct fanotify_response));
 	close(metadata->fd);
+	write(fd, &response, sizeof(struct fanotify_response));
 }
 
 void handle_events(void)

--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -300,7 +300,6 @@ static void *decision_thread_main(void *arg)
 		pthread_mutex_unlock(&decision_lock);
 
 		make_policy_decision(&metadata, fd, mask);
-		close(metadata.fd);
 	}
 	msg(LOG_DEBUG, "Exiting decision thread");
 	return NULL;

--- a/src/library/policy.c
+++ b/src/library/policy.c
@@ -410,6 +410,7 @@ void make_policy_decision(const struct fanotify_event_metadata *metadata,
 			response.response = FAN_ALLOW;
 		else
 			response.response = decision & FAN_RESPONSE_MASK;
+		close(metadata->fd);
 		write(fd, &response, sizeof(struct fanotify_response));
 	}
 }


### PR DESCRIPTION
Fix for issue #83.  Moved the metadata fd close call to happen right before the call to write in make_policy_decision and approve_event and removed it from happening after the call to make_policy_decision.