### PR TITLE
DB superset check

### DIFF
--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -10,6 +10,7 @@ BuildRequires: kernel-headers
 BuildRequires: systemd-devel libgcrypt-devel rpm-devel file-devel file
 BuildRequires: libcap-ng-devel libseccomp-devel lmdb-devel
 BuildRequires: python3-devel
+BuildRequires: uthash-devel
 Requires(pre): shadow-utils
 Requires(post): systemd-units
 Requires(preun): systemd-units


### PR DESCRIPTION
 Getting rid of the duplicate records from RPM

- checking duplicates with hash table when
  creating a list in rpmdb backend

- uthash-devel package is the new dependency

- as a sidefect we can detect when db is a superset
   of what is available from the backend

Usecase:
- when a file is added via cli as trusted, during startup `check_database_copy()` detects a new file which is not part of the db
- on the other hand when we remove the file from the trust list, `check_database_copy()` is not able to detect that file was removed it remains in db and it is considered to be trusted even after restart of the daemon
