### PR TITLE
Allow .class files instead of .java files

### DIFF
--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -237,7 +237,7 @@ static int drop_path(const char *file_name)
 						 file_name, 0) == 0)
 					return 0;
 				// Java
-				else if (fnmatch("*.java",
+				else if (fnmatch("*.class",
 						 file_name, 0) == 0)
 					return 0;
 				return 1;


### PR DESCRIPTION
`.java` files themselves aren't directly executable using the default `java`
program; instead, they must first be compiled to `.class` files (using
`javac`) before they can be executed via java. This means that `.java` files
shipped in RPMs (as say, API usage examples) won't be executed and don't
necessarily need to be. They could however, be compiled first and then
executed as `.class`; however, this resulting `.class` file should likely be
somewhere other than `/usr/share` if it wasn't distributed by the RPM
itself.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

@stevegrubb -- should we allow both? 