### PR TITLE
Fixed problem with startup failed on unlink()

### DIFF
--- a/src/library/database.c
+++ b/src/library/database.c
@@ -718,13 +718,13 @@ int unlink_db(void)
 
 	snprintf(path, sizeof(path), "%s/data.mdb", data_dir);
 	rc = unlink(path);
-	if (rc) {
+	if (rc == -1 && errno != ENOENT) {
 		msg(LOG_ERR, "Could not unlink %s (%s)", path, strerror(errno));
 		ret_val = 1;
 	}
 	snprintf(path, sizeof(path), "%s/lock.mdb", data_dir);
 	rc = unlink(path);
-	if (rc) {
+	if (rc == -1 && errno != ENOENT) {
 		msg(LOG_ERR, "Could not unlink %s (%s)", path, strerror(errno));
 		ret_val = 1;
 	}


### PR DESCRIPTION
- introduced in 128e22d0c638aed81337a6dbbfa664e5bfc9ea06

- daemon does not start when unlinking non existing db
- fapolicyd-cli returned error when there is no db to unlink

Signed-off-by: Radovan Sroka <rsroka@redhat.com>