### PR TITLE
Fix build failure with '--without-rpm'

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,7 +50,6 @@ libfapolicyd_la_SOURCES = \
 	library/process.h \
 	library/queue.c \
 	library/queue.h \
-	library/rpm-backend.c \
 	library/rules.c \
 	library/rules.h \
 	library/subject-attr.c \


### PR DESCRIPTION
Due to an oversight, the RPM backend is built unconditionally. It seems that when the option to use `--without-rpm` was added, it was not removed from the normal build.