### PR TITLE
Add trust.d directory

### DIFF
--- a/doc/fapolicyd-cli.1
+++ b/doc/fapolicyd-cli.1
@@ -21,7 +21,7 @@ Manage the file trust database.
 .RS
 .TP 12
 .B add
-This command adds the file given by path to the trust database. It gets the size and calculates the required SHA256 hash. If the path is a directory, it will walk the directory tree to the bottom and add every regular file that it finds.
+This command adds the file given by path to the trust database. It gets the size and calculates the required SHA256 hash. If the path is a directory, it will walk the directory tree to the bottom and add every regular file that it finds. By default, the path is appended to the end of the \fBfapolicyd.trust\fP file.
 .TP 12
 .B delete
 This command deletes all entries that match from the trust database. It will try to match multiple entries so that entire directories can be deleted in one command. To ensure that you only match a directory and not a partial name, be sure to end with '/'.
@@ -29,6 +29,9 @@ This command deletes all entries that match from the trust database. It will try
 .B update
 This command updates the size and hash of any matching paths in the file trust database. If no path is given, then all files are updated. If an argument is passed, then only matching paths get updated. If the intent is to match against a directory, ensure that it ends with '/'.
 .RE
+.TP
+.B \-\-trust-file trust-file-name
+Use after \fBfile\fP option. Makes every command of \fBfile\fP option operate on a single trust file named \fBtrust-file-name\fP that is located inside trust.d directory. If a trust file with such a name does not exist inside trust.d directory, it is created.
 .TP
 .B \-t, \-\-ftype /path/to/file
 Prints the mime type of the file given. A full path must be specified. This command is intended to help get the ftype parameter of rules correct by seeing how fapolicyd will classify it. Fapolicyd may differ from the \fBfile\fP command.

--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -46,6 +46,7 @@ install -p -m 644 -D init/%{name}-tmpfiles.conf %{buildroot}/%{_tmpfilesdir}/%{n
 install -p -m 644 init/%{name}.rules.known-libs %{buildroot}/%{_sysconfdir}/%{name}/%{name}.rules
 mkdir -p %{buildroot}/%{_localstatedir}/lib/%{name}
 mkdir -p %{buildroot}/run/%{name}
+mkdir -p %{buildroot}%{_sysconfdir}/%{name}/trust.d
 
 #cleanup
 find %{buildroot} \( -name '*.la' -o -name '*.a' \) -exec rm -f {} ';'
@@ -72,6 +73,7 @@ getent passwd %{name} >/dev/null || useradd -r -M -d %{_localstatedir}/lib/%{nam
 %attr(755,root,%{name}) %dir %{_datadir}/%{name}
 %attr(644,root,%{name}) %{_datadir}/%{name}/%{name}.rules.*
 %attr(750,root,%{name}) %dir %{_sysconfdir}/%{name}
+%attr(750,root,%{name}) %dir %{_sysconfdir}/%{name}/trust.d
 %config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/%{name}.conf
 %config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/%{name}.trust
 %config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/%{name}.rules
@@ -93,5 +95,5 @@ getent passwd %{name} >/dev/null || useradd -r -M -d %{_localstatedir}/lib/%{nam
 %{python3_sitelib}/dnf-plugins/__pycache__/%{name}-dnf-plugin.*.pyc
 
 %changelog
-* Thu Apr 02 2021 Steve Grubb <sgrubb@redhat.com> 1.0.4-1
+* Fri Apr 02 2021 Steve Grubb <sgrubb@redhat.com> 1.0.4-1
 - New release

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,6 @@ libfapolicyd_la_SOURCES = \
 	library/file.c \
 	library/file.h \
 	library/file-backend.c \
-	library/file-backend.h \
 	library/gcc-attributes.h \
 	library/llist.c \
 	library/llist.h \
@@ -57,7 +56,9 @@ libfapolicyd_la_SOURCES = \
 	library/subject.c \
 	library/subject.h \
 	library/string-util.c \
-	library/string-util.h
+	library/string-util.h \
+	library/trust-file.c \
+	library/trust-file.h
 
 if WITH_RPM
 libfapolicyd_la_SOURCES += library/rpm-backend.c
@@ -82,5 +83,9 @@ fapolicyd_LDADD = libfapolicyd.la
 fapolicyd_LDFLAGS += -static
 
 
-fapolicyd_cli_SOURCES = cli/fapolicyd-cli.c
+fapolicyd_cli_SOURCES = \
+	cli/fapolicyd-cli.c \
+	cli/file-cli.c \
+	cli/file-cli.h
+
 fapolicyd_cli_LDADD = libfapolicyd.la

--- a/src/cli/file-cli.c
+++ b/src/cli/file-cli.c
@@ -1,0 +1,155 @@
+/*
+ * file-cli.c - implementation of CLI option file
+ * Copyright (c) 2020 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#include <fcntl.h>
+#include <ftw.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "llist.h"
+#include "message.h"
+#include "string-util.h"
+#include "trust-file.h"
+
+
+
+#define FTW_NOPENFD 1024
+#define FTW_FLAGS (FTW_ACTIONRETVAL | FTW_PHYS)
+
+
+
+list_t add_list;
+
+
+
+static int ftw_add_list_append(const char *fpath,
+		const struct stat *sb __attribute__ ((unused)),
+		int typeflag,
+		struct FTW *ftwbuf __attribute__ ((unused)))
+{
+	if (typeflag == FTW_F)
+		list_append(&add_list, strdup(fpath), NULL);
+	return FTW_CONTINUE;
+}
+
+/**
+ * Load path into add_list. If path is a directory,
+ * loads all regular files within the directory tree
+ *
+ * @param path Path to load into add_list
+ * @return 0 on success, 1 on error
+ */
+static int add_list_load_path(const char *path)
+{
+	int fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		msg(LOG_ERR, "Cannot open %s", path);
+		return 1;
+	}
+
+	struct stat sb;
+	if (fstat(fd, &sb)) {
+		msg(LOG_ERR, "Cannot stat %s", path);
+		close(fd);
+		return 1;
+	}
+	close(fd);
+
+	if (S_ISDIR(sb.st_mode))
+		nftw(path, &ftw_add_list_append, FTW_NOPENFD, FTW_FLAGS);
+	else
+		list_append(&add_list, strdup(path), NULL);
+
+	return 0;
+}
+
+
+
+
+int file_append(const char *path, const char *fname)
+{
+	set_message_mode(MSG_STDERR, DBG_NO);
+
+	list_init(&add_list);
+	if (add_list_load_path(path))
+		return -1;
+	
+	trust_file_rm_duplicates_all(&add_list);
+
+	if (add_list.count == 0) {
+		msg(LOG_ERR, "After removing duplicates, there is nothing to add");
+		return 1;
+	}
+
+	char *dest = fname ? fapolicyd_strcat(TRUST_DIR_PATH, fname) : TRUST_FILE_PATH;
+	int rc = trust_file_append(dest, &add_list);
+
+	if (fname)
+		free(dest);
+	list_empty(&add_list);
+	return rc ? -1 : 0;
+}
+
+int file_delete(const char *path, const char *fname)
+{
+	set_message_mode(MSG_STDERR, DBG_NO);
+	int count;
+
+	if (fname) {
+		char *file = fapolicyd_strcat(TRUST_DIR_PATH, fname);
+		count = trust_file_delete_path(file, path);
+		free(file);
+	} else {
+		count = trust_file_delete_path_all(path);
+	}
+
+	if (count == 0)
+		msg(LOG_ERR, "%s is not in the trust database", path);
+
+	return !count;
+}
+
+int file_update(const char *path, const char *fname)
+{
+	set_message_mode(MSG_STDERR, DBG_NO);
+	int count;
+
+	if (fname) {
+		char *file = fapolicyd_strcat(TRUST_DIR_PATH, fname);
+		count = trust_file_update_path(file, path);
+		free(file);
+	} else {
+		count = trust_file_update_path_all(path);
+	}
+
+	if (count == 0)
+		msg(LOG_ERR, "%s is not in the trust database", path);
+
+	return !count;
+}

--- a/src/cli/file-cli.h
+++ b/src/cli/file-cli.h
@@ -1,0 +1,68 @@
+/*
+ * file-backend.h - Header file for CLI option file
+ * Copyright (c) 2020 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Steve Grubb <sgrubb@redhat.com>
+ *   Radovan Sroka <rsroka@redhat.com>
+ *   Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#ifndef FILE_CLI_H
+#define FILE_CLI_H
+
+/**
+ * Append a path into the file trust database
+ *
+ * @param path Path to append into the file trust database
+ * @param fname Filename where \p path should be written. If NULL, then
+ *     \p path is written into fapolicyd.trust file. Otherwise,
+ *     write \p path into file \p fname within the trust.d directory
+ * @return 0 on success, -1 on error and 1 if \p path already exists in
+ *     the file trust database
+ */
+int file_append(const char *path, const char *fname);
+
+/**
+ * Delete a path from the file trust database.
+ * It matches all occurrances so that a directory may be passed and
+ * all parts of it get deleted
+ *
+ * @param path Path to delete from the file trust database
+ * @param fname Filename from which \p path should be deleted. If NULL, then
+ *     \p path is deleted from fapolicyd.trust file. Otherwise,
+ *     deletes \p path from file \p fname within the trust.d directory
+ * @return 0 on success, non-zero if nothing got deleted
+ */
+int file_delete(const char *path, const char *fname);
+
+/**
+ * Update a path in the file trust database.
+ * It matches all occurrances so that a directory may be passed and
+ * all parts of it get updated
+ *
+ * @param path Path to update in the file trust database
+ * @param fname Filename in which \p path should be updated. If NULL, then
+ *     \p path is updated in fapolicyd.trust file. Otherwise,
+ *     updates \p path in file \p fname within the trust.d directory
+ * @return 0 on success, non-zero if nothing got updated
+ */
+int file_update(const char *path, const char *fname);
+
+#endif

--- a/src/library/file-backend.c
+++ b/src/library/file-backend.c
@@ -20,32 +20,20 @@
  *
  * Authors:
  *   Radovan Sroka <rsroka@redhat.com>
- *    Steve Grubb <sgrubb@redhat.com>
+ *   Steve Grubb <sgrubb@redhat.com>
+ *   Zoltan Fridrich <zfridric@redhat.com>
  */
 
 #include "config.h"
 
-#include <stdio.h>
 #include <stddef.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-#include <errno.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <ftw.h>
-#include "message.h"
-#include "file.h"
 
 #include "fapolicyd-backend.h"
 #include "llist.h"
-#include "file-backend.h"
+#include "message.h"
+#include "trust-file.h"
 
-#define FILE_PATH "/etc/fapolicyd/fapolicyd.trust"
-#define BUFFER_SIZE 4096+1+1+1+10+1+64+1
-#define FILE_READ_FORMAT  "%4096s %lu %64s"	// path size SHA256
-#define FILE_WRITE_FORMAT "%s %lu %s\n"		// path size SHA256
+
 
 static int file_init_backend(void);
 static int file_load_list(void);
@@ -61,55 +49,14 @@ backend file_backend =
 };
 
 
+
 static int file_load_list(void)
 {
-	FILE *file;
-	char buffer[BUFFER_SIZE];
-
 	msg(LOG_DEBUG, "Loading file backend");
 	list_empty(&file_backend.list);
-
-	file = fopen(FILE_PATH, "r");
-	if (!file) {
-		msg(LOG_ERR, "Cannot open %s", FILE_PATH);
-		return 1;
-	}
-
-	while (fgets(buffer, BUFFER_SIZE, file)) {
-		char name[4097], sha[65], *index, *data;
-		unsigned long sz;
-		unsigned int tsource = SRC_FILE_DB;
-
-		if (iscntrl(buffer[0]) || buffer[0] == '#')
-			continue;
-
-		if (sscanf(buffer, FILE_READ_FORMAT, name, &sz, sha) != 3) {
-			msg(LOG_WARNING, "Can't parse %s", buffer);
-			fclose(file);
-			return 1;
-		}
-
-		if (asprintf(&data, DATA_FORMAT, tsource, sz, sha) == -1)
-			data = NULL;
-
-		index = strdup(name);
-
-		//msg(LOG_INFO, "GGG: %s, %s", index, data);
-		if (index && data) {
-			if (list_append(&file_backend.list, index, data)) {
-				free(index);
-				free(data);
-			}
-		} else {
-			free(index);
-			free(data);
-		}
-	}
-
-	fclose(file);
+	trust_file_load_all(&file_backend.list);
 	return 0;
 }
-
 
 static int file_init_backend(void)
 {
@@ -117,289 +64,8 @@ static int file_init_backend(void)
 	return 0;
 }
 
-
 static int file_destroy_backend(void)
 {
 	list_empty(&file_backend.list);
 	return 0;
 }
-
-static list_t add_list;
-// Returns 1 on error and 0 otherwise
-static int check_file(const char *fpath,
-                const struct stat *sb,
-                int typeflag_unused __attribute__ ((unused)),
-                struct FTW *s_unused __attribute__ ((unused)))
-{
-        int ret = FTW_CONTINUE;
-
-        if (S_ISREG(sb->st_mode) == 0)
-                return ret;
-
-	list_append(&add_list, strdup(fpath), NULL);
-	return ret;
-}
-
-// This funtion will take a path as input and create the string to
-// be written to disk. The passed pointed must be freed by the called.
-// It returns NULL on failure. The count variable is used to select which
-// format to use. 1 = format for trust db, 0 - format for lmdb
-static char *make_data_string(const char *path, int *count)
-{
-	char *hash, *line;
-	struct stat sb;
-	int fd = open(path, O_RDONLY);
-	if (fd < 0) {
-		msg(LOG_ERR, "Cannot open %s", path);
-		return NULL;
-	}
-
-	// Get the size
-	if (fstat(fd, &sb)) {
-		msg(LOG_ERR, "Cannot stat %s", path);
-		close(fd);
-		goto err_out;
-	}
-
-	// Get the hash
-	hash = get_hash_from_fd(fd);
-	close(fd);
-
-	// Format the output
-	if (*count == 1)
-		*count = asprintf(&line, FILE_WRITE_FORMAT, path,
-						sb.st_size, hash);
-	else
-		*count = asprintf(&line, DATA_FORMAT, (unsigned int)0,
-						sb.st_size, hash);
-	free(hash);
-	if (*count < 0) {
-		msg(LOG_ERR, "Cannot format entry for %s", path);
-		goto err_out;
-	}
-	return line;
-
-err_out:
-	return NULL;
-}
-
-/*
- * This function will append a path string to the file trust database.
- * it returns 0 on success, -1 on error, and 1 if a duplicate is found.
- */
-int file_append(const char *path)
-{
-	FILE *f;
-	int fd, count;
-	char buffer[BUFFER_SIZE];
-	struct stat sb;
-	list_item_t *lptr;
-
-	set_message_mode(MSG_STDERR, DBG_NO);
-	f = fopen(FILE_PATH, "r+");
-	if (f == NULL) {
-		msg(LOG_ERR, "Cannot open %s", FILE_PATH);
-		return -1;
-	}
-
-	fd = open(path, O_RDONLY);
-	if (fd < 0) {
-		msg(LOG_ERR, "Cannot open %s", path);
-		goto err_out;
-	}
-
-	if (fstat(fd, &sb)) {
-		msg(LOG_ERR, "Cannot stat %s", path);
-		close(fd);
-		goto err_out;
-	}
-
-	// get the list of files ready to use
-	list_init(&add_list);
-	close(fd);
-
-	if (S_ISDIR(sb.st_mode)) {
-		// Build big list
-		nftw(path, check_file, 1024, FTW_PHYS);
-	} else
-		list_append(&add_list, strdup(path), NULL);
-
-	// Scan the file and look for a duplicate
-	while (fgets(buffer, BUFFER_SIZE, f)) {
-		char thash[65], tpath[4097];
-		long unsigned size;
-
-		if (iscntrl(buffer[0]) || buffer[0] == '#')
-			continue;
-
-		if (sscanf(buffer, FILE_READ_FORMAT, tpath, &size, thash) != 3){
-			msg(LOG_WARNING, "Can't parse %s", buffer);
-			fclose(f);
-			list_empty(&add_list);
-			return 1;
-		}
-		if (list_contains(&add_list, tpath))
-			list_remove(&add_list, tpath);
-	}
-
-	if (add_list.count == 0) {
-		msg(LOG_ERR,
-			"After removing duplicates, there is nothing to add");
-		fclose(f);
-		list_empty(&add_list);
-		return 1;
-	}
-
-	// No duplicate, make sure we are at the end
-	if (!feof(f))
-		fseek(f, 0, SEEK_END);
-
-	// Iterate the list an put each one to disk.
-	for (lptr = list_get_first(&add_list); lptr != NULL; lptr = lptr->next){
-		count = 1;
-		char *line = make_data_string((char *)lptr->index, &count);
-		if (line == NULL)
-			continue;	// error already output
-
-		// Write it to disk
-		if (fwrite(line, count, 1, f) != 1) {
-			msg(LOG_ERR, "failed writing to %s\n", FILE_PATH);
-			free(line);
-			goto err_out;
-		}
-		free(line);
-	}
-	fclose(f);
-	list_empty(&add_list);
-
-	return 0;
-err_out:
-	fclose(f);
-	list_empty(&add_list);
-
-	return -1;
-}
-
-
-static const char *header1 = "# This file contains a list of trusted files\n";
-static const char *header2 = "#\n";
-static const char *header3 = "#  FULL PATH        SIZE                             SHA256\n";
-static const char *header4 = "# /home/user/my-ls 157984 61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87\n";
-
-
-// This function take the passed list and writes it all to the passed
-// FILE pointer.
-static int write_out_list(list_t *list)
-{
-	list_item_t *lptr;
-	FILE *f = fopen(FILE_PATH, "w");
-	if (f == NULL) {
-		msg(LOG_ERR, "Cannot delete %s", FILE_PATH);
-		list_empty(list);
-		return 1;
-	}
-	size_t hlen = strlen(header1);
-	fwrite(header1, hlen, 1, f);
-	hlen = strlen(header2);
-	fwrite(header2, hlen, 1, f);
-	hlen = strlen(header3);
-	fwrite(header3, hlen, 1, f);
-	hlen = strlen(header4);
-	fwrite(header4, hlen, 1, f);
-	for (lptr = list_get_first(list); lptr != NULL; lptr = lptr->next) {
-		char buf[BUFFER_SIZE+1];
-		char *str = (char *)(lptr->data);
-		hlen = snprintf(buf, sizeof(buf), "%s %s\n",
-				(char *)lptr->index, &str[2]);
-		fwrite(buf, hlen, 1, f);
-	}
-	fclose(f);
-	return 0;
-}
-
-
-/*
- * This function will delete a path string from the file trust database.
- * It does this by matching all occurrances so that a directory may be
- * passed an all parts of it get deleted. It returns 0 on success, 1 on error.
- */
-int file_delete(const char *path)
-{
-	list_t *list = &file_backend.list;
-	list_item_t *lptr, *prev = NULL;
-	size_t len = strlen(path);
-	int found = 0;
-
-	set_message_mode(MSG_STDERR, DBG_NO);
-	if (file_load_list())
-		return 1;
-
-	for (lptr = list_get_first(list); lptr != NULL; lptr = lptr->next) {
-		if (strncmp(lptr->index, path, len) == 0) {
-			found = 1;
-			if (prev)
-				prev->next = lptr->next;
-			else
-				list->first = NULL;
-
-			list->count--;
-			list_destroy_item(&lptr);
-			if (prev)
-				lptr = prev;
-			else
-				break;
-		}
-		prev = lptr;
-	}
-
-	if (!found) {
-		msg(LOG_ERR, "%s is not in the trust database", path);
-		list_empty(list);
-		return 1;
-	}
-
-	// Now write everything back out
-	int rc = write_out_list(list);
-	list_empty(list);
-
-	return rc;
-}
-
-
-int file_update(const char *path)
-{
-	// Load file list
-	list_t *list = &file_backend.list;
-	list_item_t *lptr;
-	int found = 0;
-	size_t len = strlen(path);
-
-	set_message_mode(MSG_STDERR, DBG_NO);
-	if (file_load_list())
-		return 1;
-
-	// match against passed string
-	for (lptr = list_get_first(list); lptr != NULL; lptr = lptr->next) {
-		// delete data field for matches
-		if (strncmp(lptr->index, path, len) == 0) {
-			int i = 0;	// unused
-			free((char *)lptr->data);
-			// make new data field
-			lptr->data = make_data_string((char *)lptr->index, &i);
-			found = 1;
-		}
-	}
-
-	if (!found) {
-		msg(LOG_ERR, "%s is not in the trust database", path);
-		list_empty(list);
-		return 1;
-	}
-
-	// write it all out
-	int rc = write_out_list(list);
-	list_empty(list);
-
-	return rc;
-}
-

--- a/src/library/llist.h
+++ b/src/library/llist.h
@@ -20,6 +20,7 @@
  *
  * Authors:
  *   Radovan Sroka <rsroka@redhat.com>
+ *   Zoltan Fridrich <zfridric@redhat.com>
  */
 
 #ifndef LLIST_H
@@ -43,6 +44,7 @@ int list_append(list_t *list, const char *index, const char *data);
 void list_destroy_item(list_item_t **item);
 void list_empty(list_t *list);
 int list_contains(list_t *list, const char *str);
-void list_remove(list_t *list, const char *str);
+int list_remove(list_t *list, const char *str);
+void list_merge(list_t *dest, list_t *src);
 
 #endif

--- a/src/library/string-util.c
+++ b/src/library/string-util.c
@@ -20,10 +20,13 @@
  *
  * Authors:
  *   Radovan Sroka <rsroka@redhat.com>
+ *   Zoltan Fridrich <zfridric@redhat.com>
  */
 
-#include <stdio.h>
 #include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "string-util.h"
 
@@ -51,3 +54,12 @@ char *fapolicyd_strtrim(char *s)
 	return s;
 }
 
+char *fapolicyd_strcat(const char *s1, const char *s2)
+{
+	size_t s1_len = strlen(s1);
+	size_t s2_len = strlen(s2);
+	char *r = malloc(s1_len + s2_len + 1);
+	strcpy(r, s1);
+	strcat(r, s2);
+	return r;
+}

--- a/src/library/string-util.h
+++ b/src/library/string-util.h
@@ -20,11 +20,21 @@
  *
  * Authors:
  *   Radovan Sroka <rsroka@redhat.com>
+ *   Zoltan Fridrich <zfridric@redhat.com>
  */
 
 #ifndef STRING_UTIL_H
 #define STRING_UTIL_H
 
 char *fapolicyd_strtrim(char *s);
+
+/**
+ * Concatenates two NULL terminated strings
+ *
+ * @param s1 First NULL terminated string
+ * @param s2 Second NULL terminated string
+ * @return Dynamically allocated NULL terminated string s1||s2
+ */
+char *fapolicyd_strcat(const char *s1, const char *s2);
 
 #endif

--- a/src/library/trust-file.c
+++ b/src/library/trust-file.c
@@ -1,0 +1,397 @@
+/*
+ * trust-file.c - Functions for working with trust files 
+ * Copyright (c) 2020 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Zoltan Fridrich <zfridric@redhat.com>
+ */
+
+#include "config.h"
+
+#include <ctype.h>
+#include <fcntl.h>
+#include <ftw.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "fapolicyd-backend.h"
+#include "file.h"
+#include "llist.h"
+#include "message.h"
+#include "trust-file.h"
+
+
+
+#define TRUST_FILE_PATH "/etc/fapolicyd/fapolicyd.trust"
+#define TRUST_DIR_PATH "/etc/fapolicyd/trust.d/"
+#define BUFFER_SIZE 4096+1+1+1+10+1+64+1
+#define FILE_READ_FORMAT  "%4096s %lu %64s" // path size SHA256
+#define FILE_WRITE_FORMAT "%s %lu %s\n"     // path size SHA256
+#define FTW_NOPENFD 1024
+#define FTW_FLAGS (FTW_ACTIONRETVAL | FTW_PHYS)
+
+#define HEADER1 "# This file contains a list of trusted files\n"
+#define HEADER2 "#\n"
+#define HEADER3 "#  FULL PATH        SIZE                             SHA256\n"
+#define HEADER4 "# /home/user/my-ls 157984 61a9960bf7d255a85811f4afcac51067b8f2e4c75e21cf4f2af95319d4ed1b87\n"
+
+
+
+list_t _list;
+char *_path;
+int _count;
+
+
+
+/**
+ * Take a path and create a string that is ready to be written to the disk.
+ *
+ * @param path Path to create a string from
+ * @param count The count variable is used to select which format to use.
+ *    non-zero = trust db format, zero = lmdb format.
+ *    Writes the size of the path string into the \p count at the end
+ * @return Path string ready to be written to the disk or NULL on error 
+ */
+static char *make_path_string(const char *path, int *count)
+{
+	int fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		msg(LOG_ERR, "Cannot open %s", path);
+		return NULL;
+	}
+
+	// Get the size
+	struct stat sb;
+	if (fstat(fd, &sb)) {
+		msg(LOG_ERR, "Cannot stat %s", path);
+		close(fd);
+		return NULL;
+	}
+
+	// Get the hash
+	char *hash = get_hash_from_fd(fd);
+	close(fd);
+
+	// Format the output
+	char *line;
+	*count = *count ?
+		asprintf(&line, FILE_WRITE_FORMAT, path, sb.st_size, hash) :
+		asprintf(&line, DATA_FORMAT, 0, sb.st_size, hash);
+	free(hash);
+
+	if (*count < 0) {
+		msg(LOG_ERR, "Cannot format entry for %s", path);
+		return NULL;
+	}
+	return line;
+}
+
+/**
+ * Write a list into a file
+ *
+ * @param list List to write into a file
+ * @param dest Destination file
+ * @return 0 on success, 1 on error
+ */
+static int write_out_list(list_t *list, const char *dest)
+{
+	FILE *f = fopen(dest, "w");
+	if (!f) {
+		msg(LOG_ERR, "Cannot delete %s", dest);
+		list_empty(list);
+		return 1;
+	}
+
+	size_t hlen = strlen(HEADER1);
+	fwrite(HEADER1, hlen, 1, f);
+	hlen = strlen(HEADER2);
+	fwrite(HEADER2, hlen, 1, f);
+	hlen = strlen(HEADER3);
+	fwrite(HEADER3, hlen, 1, f);
+	hlen = strlen(HEADER4);
+	fwrite(HEADER4, hlen, 1, f);
+
+	for (list_item_t *lptr = list->first; lptr; lptr = lptr->next) {
+		char buf[BUFFER_SIZE + 1];
+		char *str = (char *)(lptr->data);
+		hlen = snprintf(buf, sizeof(buf), "%s %s\n", (char *)lptr->index, str + 2);
+		fwrite(buf, hlen, 1, f);
+	}
+
+	fclose(f);
+	return 0;
+}
+
+
+
+int trust_file_append(const char *fpath, const list_t *list) {
+	int fd = open(fpath, O_CREAT | O_WRONLY | O_APPEND, 0600);
+	if (fd == -1) {
+		msg(LOG_ERR, "Cannot open %s", fpath);
+		return 1;
+	}
+
+	for (list_item_t *lptr = list->first; lptr; lptr = lptr->next) {
+		int count = 1;
+		char *line = make_path_string(lptr->index, &count);
+		if (!line)
+			continue;
+
+		if (write(fd, line, count) == -1) {
+			msg(LOG_ERR, "failed writing to %s\n", fpath);
+			free(line);
+			close(fd);
+			return 2;
+		}
+		free(line);
+	}
+
+	close(fd);
+	return 0;
+}
+
+int trust_file_load(const char *fpath, list_t *list)
+{
+	FILE *file = fopen(fpath, "r");
+	if (!file) {
+		msg(LOG_ERR, "Cannot open %s", fpath);
+		return 1;
+	}
+
+	char buffer[BUFFER_SIZE];
+	while (fgets(buffer, BUFFER_SIZE, file)) {
+		char name[4097], sha[65], *index, *data;
+		unsigned long sz;
+		unsigned int tsource = SRC_FILE_DB;
+
+		if (iscntrl(buffer[0]) || buffer[0] == '#')
+			continue;
+
+		if (sscanf(buffer, FILE_READ_FORMAT, name, &sz, sha) != 3) {
+			msg(LOG_WARNING, "Can't parse %s", buffer);
+			fclose(file);
+			return 2;
+		}
+
+		if (asprintf(&data, DATA_FORMAT, tsource, sz, sha) == -1)
+			data = NULL;
+
+		index = strdup(name);
+
+		if (!index || !data) {
+			free(index);
+			free(data);
+			continue;
+		}
+
+		if (list_contains(list, index)) {
+			msg(LOG_WARNING, "%s contains a duplicate %s", fpath, index);
+			free(index);
+			free(data);
+			continue;
+		}
+
+		if (list_append(list, index, data)) {
+			free(index);
+			free(data);
+		}
+	}
+
+	fclose(file);
+	return 0;
+}
+
+int trust_file_delete_path(const char *fpath, const char *path)
+{
+	list_t list;
+	list_init(&list);
+	trust_file_load(fpath, &list);
+
+	int count = 0;
+	size_t path_len = strlen(path);
+	list_item_t *lptr = list.first, *prev = NULL, *tmp;
+
+	while (lptr) {
+		if (!strncmp(lptr->index, path, path_len)) {
+			++count;
+			tmp = lptr->next;
+
+			if (prev)
+				prev->next = lptr->next;
+			else
+				list.first = lptr->next;
+			if (!lptr->next)
+				list.last = prev;
+			--list.count;
+			list_destroy_item(&lptr);
+
+			lptr = tmp;
+			continue;
+		}
+		prev = lptr;
+		lptr = lptr->next;
+	}
+
+	if (count)
+		write_out_list(&list, fpath);
+
+	list_empty(&list);
+	return count;
+}
+
+int trust_file_update_path(const char *fpath, const char *path)
+{
+	list_t list;
+	list_init(&list);
+	trust_file_load(fpath, &list);
+
+	int count = 0;
+	size_t path_len = strlen(path);
+
+	for (list_item_t *lptr = list.first; lptr; lptr = lptr->next) {
+		if (!strncmp(lptr->index, path, path_len)) {
+			int i = 0;
+			free((char *)lptr->data);
+			lptr->data = make_path_string(lptr->index, &i);
+			++count;
+		}
+	}
+
+	if (count)
+		write_out_list(&list, fpath);
+
+	list_empty(&list);
+	return count;
+}
+
+int trust_file_rm_duplicates(const char *fpath, list_t *list)
+{
+	FILE *file = fopen(fpath, "r");
+	if (!file) {
+		msg(LOG_ERR, "Cannot open %s", fpath);
+		return 1;
+	}
+
+	char buffer[BUFFER_SIZE];
+	while (fgets(buffer, BUFFER_SIZE, file)) {
+		char thash[65], tpath[4097];
+		long unsigned size;
+
+		if (iscntrl(buffer[0]) || buffer[0] == '#')
+			continue;
+
+		if (sscanf(buffer, FILE_READ_FORMAT, tpath, &size, thash) != 3) {
+			msg(LOG_WARNING, "Can't parse %s", buffer);
+			fclose(file);
+			return 2;
+		}
+
+		list_remove(list, tpath);
+		if (list->count == 0)
+			break;
+	}
+
+	fclose(file);
+	return 0;
+}
+
+
+
+static int ftw_load(const char *fpath,
+		const struct stat *sb __attribute__ ((unused)),
+		int typeflag,
+		struct FTW *ftwbuf __attribute__ ((unused)))
+{
+	if (typeflag == FTW_F)
+		trust_file_load(fpath, &_list);
+	return FTW_CONTINUE;
+}
+
+static int ftw_delete_path(const char *fpath,
+		const struct stat *sb __attribute__ ((unused)),
+		int typeflag,
+		struct FTW *ftwbuf __attribute__ ((unused)))
+{
+	if (typeflag == FTW_F)
+		_count += trust_file_delete_path(fpath, _path);
+	return FTW_CONTINUE;
+}
+
+static int ftw_update_path(const char *fpath,
+		const struct stat *sb __attribute__ ((unused)),
+		int typeflag,
+		struct FTW *ftwbuf __attribute__ ((unused)))
+{
+	if (typeflag == FTW_F)
+		_count += trust_file_update_path(fpath, _path);
+	return FTW_CONTINUE;
+}
+
+static int ftw_rm_duplicates(const char *fpath,
+		const struct stat *sb __attribute__ ((unused)),
+		int typeflag,
+		struct FTW *ftwbuf __attribute__ ((unused)))
+{
+	if (_list.count == 0)
+		return FTW_STOP;
+	if (typeflag == FTW_F)
+		trust_file_rm_duplicates(fpath, &_list);
+	return FTW_CONTINUE;
+}
+
+
+
+void trust_file_load_all(list_t *list)
+{
+	list_empty(&_list);
+	trust_file_load(TRUST_FILE_PATH, &_list);
+	nftw(TRUST_DIR_PATH, &ftw_load, FTW_NOPENFD, FTW_FLAGS);
+	list_merge(list, &_list);
+}
+
+int trust_file_delete_path_all(const char *path)
+{
+	_path = strdup(path);
+	_count = trust_file_delete_path(TRUST_FILE_PATH, path);
+	nftw(TRUST_DIR_PATH, &ftw_delete_path, FTW_NOPENFD, FTW_FLAGS);
+	free(_path);
+	return _count;
+}
+
+int trust_file_update_path_all(const char *path)
+{
+	_path = strdup(path);
+	_count = trust_file_update_path(TRUST_FILE_PATH, path);
+	nftw(TRUST_DIR_PATH, &ftw_update_path, FTW_NOPENFD, FTW_FLAGS);
+	free(_path);
+	return _count;
+}
+
+void trust_file_rm_duplicates_all(list_t *list)
+{
+	list_empty(&_list);
+	list_merge(&_list, list);
+	trust_file_rm_duplicates(TRUST_FILE_PATH, &_list);
+	nftw(TRUST_DIR_PATH, &ftw_rm_duplicates, FTW_NOPENFD, FTW_FLAGS);
+	list_merge(list, &_list);
+}

--- a/src/library/trust-file.h
+++ b/src/library/trust-file.h
@@ -1,5 +1,5 @@
 /*
- * file-backend.h - Header file for management functions of file-backend.c
+ * trust-file.h - Header for managing trust files
  * Copyright (c) 2020 Red Hat Inc.
  * All Rights Reserved.
  *
@@ -19,16 +19,27 @@
  * Boston, MA 02110-1335, USA.
  *
  * Authors:
- *   Steve Grubb <sgrubb@redhat.com>
- *   Radovan Sroka <rsroka@redhat.com>
+ *   Zoltan Fridrich <zfridric@redhat.com>
  */
 
-#ifndef FILE_BACKEND_HEADER
-#define FILE_BACKEND_HEADER
+#ifndef TRUST_FILE_H
+#define TRUST_FILE_H
 
-int file_append(const char *path);
-int file_delete(const char *path);
-int file_update(const char *path);
+#include "llist.h"
+
+#define TRUST_FILE_PATH "/etc/fapolicyd/fapolicyd.trust"
+#define TRUST_DIR_PATH "/etc/fapolicyd/trust.d/"
+
+int trust_file_append(const char *fpath, const list_t *list);
+
+int trust_file_load(const char *fpath, list_t *list);
+int trust_file_update_path(const char *fpath, const char *path);
+int trust_file_delete_path(const char *fpath, const char *path);
+int trust_file_rm_duplicates(const char *fpath, list_t *list);
+
+void trust_file_load_all(list_t *list);
+int trust_file_update_path_all(const char *path);
+int trust_file_delete_path_all(const char *path);
+void trust_file_rm_duplicates_all(list_t *list);
 
 #endif
-


### PR DESCRIPTION
This commit implements trust.d directory.

What exactly changed:

-  after installing fapolicyd a trust.d directory is created inside /etc/fapolicyd/ with 750 permissions.
-  **fapolicyd-cli --file add path** now appends into fapolicyd.trust file located inside /etc/fapolicyd/ by default
- **fapolicyd-cli --file delete path** deletes a path from all trust files by default. ie. it deletes path from fapolicyd.trust + all of the trust files located inside trust.d directory
- **fapolicyd-cli --file update path** updates a path in all trust files by default
- user can now use option **--trust-file file-name** after **--file** to specify a trust file inside a trust.d directory to operate on

Example usage:
**fapolicyd-cli --file add path --trust-file fname**
this will append a path **path** into a trust file named **fname** that resides inside trust.d directory. If a trust file with a name **fname** does not exist inside trust.d directory, it will be created with permissions set to 600

Closes #122