### PR TITLE
Remove unnecessary ansible rules

### DIFF
--- a/init/fapolicyd.rules.known-libs
+++ b/init/fapolicyd.rules.known-libs
@@ -28,10 +28,6 @@ deny_audit perm=open all : ftype=application/x-sharedlib
 # Allow trusted programs to execute
 allow perm=execute all : trust=1
 
-# Need to carve out an exception for ansible, which uses python
-allow perm=any uid=0 : dir=/tmp/ansible
-allow perm=any uid=0 : dir=/root/.ansible/tmp/
-
 # Allow any program to open trusted language files
 allow perm=open all : ftype=%languages trust=1
 deny_audit perm=any all : ftype=%languages

--- a/init/fapolicyd.rules.restrictive
+++ b/init/fapolicyd.rules.restrictive
@@ -45,10 +45,6 @@ deny_audit perm=execute all : ftype=application/x-executable
 # in rule 3.
 allow perm=execute all : path=%ld_so_path% trust=1
 
-# Need to carve out an exception for ansible, which uses python
-allow perm=any uid=0 : dir=/tmp/ansible
-allow perm=any uid=0 : dir=/root/.ansible/tmp/
-
 # Only allow system python executables and libs
 # File type by: fapolicyd-cli --ftype /path-to-file
 allow perm=any all : ftype=text/x-python trust=1


### PR DESCRIPTION
Ansible is currently using /var/tmp directory to store its python scripts. There is already a dracut rule that allows this directory.