### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/library/file.c
+++ b/src/library/file.c
@@ -501,7 +501,7 @@ static Elf32_Ehdr *read_header32(int fd)
 {
 	Elf32_Ehdr *ptr = malloc(sizeof(Elf32_Ehdr));
 	memcpy(ptr->e_ident, e_ident, EI_NIDENT);
-	ssize_t rc = safe_read(fd, (char *)&(ptr->e_type),
+	ssize_t rc = safe_read(fd, (char *)ptr + EI_NIDENT,
 				sizeof(Elf32_Ehdr) - EI_NIDENT);
 	if (rc == (sizeof(Elf32_Ehdr) - EI_NIDENT))
 		return ptr;
@@ -515,7 +515,7 @@ static Elf64_Ehdr *read_header64(int fd)
 {
 	Elf64_Ehdr *ptr = malloc(sizeof(Elf64_Ehdr));
 	memcpy(ptr->e_ident, e_ident, EI_NIDENT);
-	ssize_t rc = safe_read(fd, (char *)&(ptr->e_type),
+	ssize_t rc = safe_read(fd, (char *)ptr + EI_NIDENT,
 				sizeof(Elf64_Ehdr) - EI_NIDENT);
 	if (rc == (sizeof(Elf64_Ehdr) - EI_NIDENT))
 		return ptr;


### PR DESCRIPTION
Fixes following warnings:

```
    In function ‘safe_read’,
        inlined from ‘read_header32’ at library/file.c:504:15,
        inlined from ‘gather_elf’ at library/file.c:560:21:
    library/file.c:409:23: warning: ‘read’ writing 36 bytes into a region of size 2 overflows the destination [-Wstringop-overflow=]
      409 |                 len = read(fd, buf, size);
          |                       ^~~~~~~~~~~~~~~~~~~
    In file included from library/file.c:37:
    library/file.c: In function ‘gather_elf’:
    /usr/include/elf.h:66:17: note: destination object ‘e_type’ of size 2
       66 |   Elf32_Half    e_type;                 /* Object file type */
          |                 ^~~~~~
    In file included from library/file.c:30:
    /usr/include/unistd.h:371:16: note: in a call to function ‘read’ declared with attribute ‘access (write_only, 2, 3)’
      371 | extern ssize_t read (int __fd, void *__buf, size_t __nbytes) __wur
          |                ^~~~
    In function ‘safe_read’,
        inlined from ‘read_header64’ at library/file.c:518:15,
        inlined from ‘gather_elf’ at library/file.c:716:21:
    library/file.c:409:23: warning: ‘read’ writing 48 bytes into a region of size 2 overflows the destination [-Wstringop-overflow=]
      409 |                 len = read(fd, buf, size);
          |                       ^~~~~~~~~~~~~~~~~~~
    In file included from library/file.c:37:
    library/file.c: In function ‘gather_elf’:
    /usr/include/elf.h:84:17: note: destination object ‘e_type’ of size 2
       84 |   Elf64_Half    e_type;                 /* Object file type */
          |                 ^~~~~~
    In file included from library/file.c:30:
    /usr/include/unistd.h:371:16: note: in a call to function ‘read’ declared with attribute ‘access (write_only, 2, 3)’
      371 | extern ssize_t read (int __fd, void *__buf, size_t __nbytes) __wur
          |                ^~~~

```