### PR TITLE
Expand libc sharedlib detection

### DIFF
--- a/src/library/file.c
+++ b/src/library/file.c
@@ -295,6 +295,7 @@ const char *classify_elf_info(uint32_t elf, const char *path)
 			if (!strncmp(p, "64", 2))
 				p += 2;
 			if (!strncmp(p, "/libc-2", 7) ||
+				!strncmp(p, "/libc.so", 8) ||
 				!strncmp(p, "/libpthread-2", 13))
 				ptr = "application/x-sharedlib";
 		}


### PR DESCRIPTION
Expand libc detection to detect simlinks like /lib64/libc.so.0 etc.