### PR TITLE
Some spec nitpicks

### DIFF
--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -102,12 +102,12 @@ fi
 %attr(644,root,root) %{_mandir}/man5/*
 %attr(644,root,root) %{_mandir}/man1/*
 %attr(644,root,root) %{_datadir}/%{name}/*
-%ghost %{_localstatedir}/log/%{name}-access.log
+%ghost %attr(440,%{name},%{name}) %verify(not md5 size maj min mtime) %{_localstatedir}/log/%{name}-access.log
 %attr(770,root,%{name}) %dir %{_localstatedir}/lib/%{name}
 %attr(770,root,%{name}) %dir /run/%{name}
-%ghost /run/%{name}/%{name}.fifo
-%ghost %{_localstatedir}/lib/%{name}/data.mdb
-%ghost %{_localstatedir}/lib/%{name}/lock.mdb
+%ghost %attr(660,root,%{name}) /run/%{name}/%{name}.fifo
+%ghost %attr(660,%{name},%{name}) %verify(not md5 size maj min mtime) %{_localstatedir}/lib/%{name}/data.mdb
+%ghost %attr(660,%{name},%{name}) %verify(not md5 size maj min mtime) %{_localstatedir}/lib/%{name}/lock.mdb
 %{python3_sitelib}/dnf-plugins/%{name}-dnf-plugin.py
 %{python3_sitelib}/dnf-plugins/__pycache__/%{name}-dnf-plugin.*.pyc
 

--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -51,7 +51,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}/trust.d
 mkdir -p %{buildroot}%{_sysconfdir}/%{name}/rules.d
 
 #cleanup
-find %{buildroot} \( -name '*.la' -o -name '*.a' \) -exec rm -f {} ';'
+find %{buildroot} \( -name '*.la' -o -name '*.a' \) -delete
 
 %check
 make check

--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -37,10 +37,10 @@ sed -i "s/%ld_so_path%/`find /usr/lib64/ -type f -name 'ld-2\.*.so' | sed 's/\//
     --with-audit \
     --disable-shared
 
-make CFLAGS="%{optflags}" %{?_smp_mflags}
+%make_build
 
 %install
-make DESTDIR="%{buildroot}" INSTALL='install -p' install
+%make_install
 mkdir -p %{buildroot}/%{python3_sitelib}/dnf-plugins/
 install -p -m 644 dnf/%{name}-dnf-plugin.py %{buildroot}/%{python3_sitelib}/dnf-plugins/
 install -p -m 644 -D init/%{name}-tmpfiles.conf %{buildroot}/%{_tmpfilesdir}/%{name}.conf


### PR DESCRIPTION
Use normal macros
Use find -delete when removing files
After installing and running package:
```
rpm -V <packagename>
```
should not provide any regressions if user did not modify any file.

```
% sudo rpm -V fapolicyd
.M....G..  g /run/fapolicyd/fapolicyd.fifo
.M...UG..  g /var/lib/fapolicyd/data.mdb
.M...UG..  g /var/lib/fapolicyd/lock.mdb
.M...UG..  g /var/log/fapolicyd-access.log
```

```
% sudo ls -lad /var/lib/fapolicyd/data.mdb /var/lib/fapolicyd/lock.mdb /var/log/fapolicyd-access.log
-rw-rw----. 1 fapolicyd fapolicyd 41943040 29.12. 21:31 /var/lib/fapolicyd/data.mdb
-rw-rw----. 1 fapolicyd fapolicyd      384 29.12. 21:31 /var/lib/fapolicyd/lock.mdb
-r--r-----. 1 fapolicyd fapolicyd    12545 29.12. 21:31 /var/log/fapolicyd-access.log
% sudo ls -lad /run/fapolicyd/fapolicyd.fifo
prw-rw----. 1 root fapolicyd 0 29.12. 21:37 /run/fapolicyd/fapolicyd.fifo
```

```
% rpm -q --dump fapolicyd
...
/run/fapolicyd/fapolicyd.fifo 0 1639157399 0000000000000000000000000000000000000000000000000000000000000000 0100000 root root 0 0 0 X
...
/var/lib/fapolicyd/data.mdb 0 1639157399 0000000000000000000000000000000000000000000000000000000000000000 0100000 root root 0 0 0 X
/var/lib/fapolicyd/lock.mdb 0 1639157399 0000000000000000000000000000000000000000000000000000000000000000 0100000 root root 0 0 0 X
/var/log/fapolicyd-access.log 0 1639157399 0000000000000000000000000000000000000000000000000000000000000000 0100000 root root 0 0 0 X
```