### PR TITLE
Unconfined root

### DIFF
--- a/rules.d/20-dracut.rules
+++ b/rules.d/20-dracut.rules
@@ -1,5 +1,4 @@
-# Carve out an exception for dracut's initramfs building
+# Root user can pretty much do what it wants, no reason to waive specific operations
 
-allow perm=any uid=0 : dir=/var/tmp/
-allow perm=any uid=0 trust=1 : all
+allow perm=any uid=0 : all
 


### PR DESCRIPTION
Any process with root privileges can stop fapolicyd, run trusted python code, or shell script pipe+exec. 
No rule fapolicyd can be of any real value.

The fact there are those specific workarounds only shows some projects don't give a shit
about fapolicyd, while other will have to fapolicyd-cli file add their stuff praying fapolicyd
won't change their API tomorrow.