### PR TITLE
Use the non-blocking event type in permissive mode and fix case of leaking file descriptors

### DIFF
--- a/src/library/policy.c
+++ b/src/library/policy.c
@@ -271,7 +271,7 @@ static char *format_value(int item, unsigned int num, decision_t results,
 			break;
 		case F_PERM:
 			if (asprintf(&out, "%s",
-					e->type & FAN_OPEN_EXEC_PERM ?
+					e->type & (FAN_OPEN_EXEC_PERM|FAN_OPEN_EXEC) ?
 					"execute" : "open") < 0)
 				out = NULL;
 			break;
@@ -427,18 +427,19 @@ void make_policy_decision(const struct fanotify_event_metadata *metadata,
 	else
 		decision = process_event(&e);
 
+	close(metadata->fd);
+
 	if ((decision & DENY) == DENY)
 		denied++;
 	else
 		allowed++;
-
+	
 	if (metadata->mask & mask) {
 		response.fd = metadata->fd;
 		if (permissive)
 			response.response = FAN_ALLOW | (decision & AUDIT);
 		else
 			response.response = decision & FAN_RESPONSE_MASK;
-		close(metadata->fd);
 		write(fd, &response, sizeof(struct fanotify_response));
 	}
 }

--- a/src/library/policy.c
+++ b/src/library/policy.c
@@ -433,7 +433,7 @@ void make_policy_decision(const struct fanotify_event_metadata *metadata,
 		denied++;
 	else
 		allowed++;
-	
+
 	if (metadata->mask & mask) {
 		response.fd = metadata->fd;
 		if (permissive)

--- a/src/library/rules.c
+++ b/src/library/rules.c
@@ -1050,7 +1050,7 @@ static int subj_pattern_test(const subject_attr_t *s, event_t *e)
 			goto make_decision;
 		} else if (pinfo->state == STATE_STATIC_PARTIAL)
 			goto make_decision;
-		else if ((e->type & FAN_OPEN_EXEC_PERM) && pinfo->path1 &&
+		else if ((e->type & (FAN_OPEN_EXEC_PERM|FAN_OPEN_EXEC)) && pinfo->path1 &&
 				strcmp(pinfo->path1, SYSTEM_LD_SO) == 0) {
 			pinfo->state = STATE_LD_SO;
 			goto make_decision;
@@ -1118,7 +1118,7 @@ static int check_access(const lnode *r, const event_t *e)
 	if (r->a == ANY_ACC)
 		return 1;
 
-	if (e->type & FAN_OPEN_EXEC_PERM)
+	if (e->type & (FAN_OPEN_EXEC_PERM|FAN_OPEN_EXEC))
 		perm = EXEC_ACC;
 	else
 		perm = OPEN_ACC;


### PR DESCRIPTION
`fanotify` supports `FAN_OPEN` and `FAN_OPEN_EXEC` which do not block on receiving a decision. For our use case of having `fapolicyd` produce logs which we then can analyze asynchronously, this can boost performance significantly.

In addition when testing, we noticed that if the internal event queue fills, we do not close the event's file descriptor, which results in the process accumulating them over time if the queue size is not properly configured.

(co-authored by @kenbreeman)