### PR TITLE
Close event file descriptor on enqueue failure

### DIFF
--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -322,8 +322,10 @@ out:
 
 static void enqueue_event(const struct fanotify_event_metadata *metadata)
 {
-	if (q_append(q, metadata))
+	if (q_append(q, metadata)){
 		msg(LOG_DEBUG, "enqueue error");
+		close(metadata->fd);
+	}
 	else
 		set_ready();
 }


### PR DESCRIPTION
When the internal event queue fills, we do not close the event's file descriptor, which results in the process accumulating them over time if the queue size is not properly configured.