### PR TITLE
End long_opts array with NULL row

### DIFF
--- a/src/cli/fapolicyd-cli.c
+++ b/src/cli/fapolicyd-cli.c
@@ -80,6 +80,7 @@ static struct option long_opts[] =
 	{"ftype",	1, NULL, 't'},
 	{"list",	0, NULL, 'l'},
 	{"update",	0, NULL, 'u'},
+	{ NULL,		0, NULL, 0 }
 };
 
 #define STAT_REPORT "/var/run/fapolicyd.state"


### PR DESCRIPTION
- otherwise CLI (with non valid long opt) segaults on RHEL8

Signed-off-by: Radovan Sroka <rsroka@redhat.com>