### PR TITLE
CLI uses new line in update notification message

### DIFF
--- a/src/cli/fapolicyd-cli.c
+++ b/src/cli/fapolicyd-cli.c
@@ -487,7 +487,7 @@ static int do_update(void)
 		}
 	}
 
-	ssize_t ret = write(fd, "1", 2);
+	ssize_t ret = write(fd, "1\n", 2);
 
 	if (ret == -1) {
 		fprintf(stderr, "Write: %s -> %s\n", _pipe, strerror(errno));


### PR DESCRIPTION
- after work on 850d2a new line is required for correct parsing in
  update thread
- we were acciidentally sending string termination char as a part of the
  message, we don't want that now

Signed-off-by: Radovan Sroka <rsroka@redhat.com>