### PR TITLE
Bugfixes for the dnf plugin

### DIFF
--- a/dnf/fapolicyd-dnf-plugin.py
+++ b/dnf/fapolicyd-dnf-plugin.py
@@ -8,7 +8,7 @@ import sys
 class Fapolicyd(dnf.Plugin):
 
     name = "fapolicyd"
-    pipe = "/var/run/fapolicyd/fapolicyd.fifo"
+    pipe = "/run/fapolicyd/fapolicyd.fifo"
     file = None
 
     def __init__(self, base, cli):
@@ -32,5 +32,5 @@ class Fapolicyd(dnf.Plugin):
             sys.stderr.write("fapolicy-plugin does not have write permission: " + self.pipe + "\n")
             return
 
-        self.file.write("1")
+        self.file.write("1\n")
         self.file.close()


### PR DESCRIPTION
* Point to the correct fifo path (as referenced in [paths.h](https://github.com/linux-application-whitelisting/fapolicyd/blob/main/src/library/paths.h#L37))
* Write a newline to get fapolicyd to pick up the write

cc. @kenbreeman