### PR TITLE
Add `FAN_MARK_MOUNT` when opting out of `FAN_MARK_FILESYSTEM`

### DIFF
--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -128,10 +128,13 @@ retry_mark:
 #if defined HAVE_DECL_FAN_MARK_FILESYSTEM && HAVE_DECL_FAN_MARK_FILESYSTEM != 0
 		if (conf->allow_filesystem_mark)
 		    flags |= FAN_MARK_FILESYSTEM;
+		else
+		    flags |= FAN_MARK_MOUNT;
 #else
 		if (conf->allow_filesystem_mark)
 			msg(LOG_ERR,
 	    "allow_filesystem_mark is unsupported for this kernel - ignoring");
+		flags |= FAN_MARK_MOUNT;
 #endif
 		if (fanotify_mark(fd, flags, mask, -1, path) == -1) {
 			/*


### PR DESCRIPTION
As of upgrading to v1.1.6, we noticed that we were no longer receiving events since we didn't opt in for monitoring bind mounted accesses via the config option. 

Without `FAN_MARK_MOUNT` added to the flags set in `fanotify_mark`, fapolicyd does not receive events for any subdirectories specified by the path parameter.

cc. @kenbreeman