### PR TITLE
RPM backend: Add missing #include <rpm/rpmpgp.h>

### DIFF
--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -30,6 +30,7 @@
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmlog.h>
 #include <rpm/rpmdb.h>
+#include <rpm/rpmpgp.h>
 #include <fnmatch.h>
 
 #include <uthash.h>


### PR DESCRIPTION
It is needed for the rpmFreeCrypto function.