### PR TITLE
Get bash path with command

### DIFF
--- a/m4/dyn_linker.m4
+++ b/m4/dyn_linker.m4
@@ -1,6 +1,7 @@
 AC_DEFUN([LD_SO_PATH],
 [
-  xpath1=`readelf -e /usr/bin/bash | grep Requesting | sed 's/.$//' | rev | cut -d" " -f1 | rev`
+  bash_path=`command -v bash`
+  xpath1=`readelf -e $bash_path | grep Requesting | sed 's/.$//' | rev | cut -d" " -f1 | rev`
   xpath=`realpath $xpath1`
   if test ! -f "$xpath" ; then
     AC_MSG_ERROR([Cant find the dynamic linker])


### PR DESCRIPTION
The command path is different in the distribution. This is not the hard code, but the implementation obtained with 'command' command.

Signed-off-by: Nobuhiro Iwamatsu <iwamatsu@nigauri.org>