### PR TITLE
Introduce filtering of rpmdb

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -28,4 +28,5 @@ man_MANS = \
 	fapolicyd-cli.1 \
 	fapolicyd.rules.5 \
 	fapolicyd.trust.5 \
-	fapolicyd.conf.5
+	fapolicyd.conf.5 \
+	rpm-filter.conf.5

--- a/doc/rpm-filter.conf.5
+++ b/doc/rpm-filter.conf.5
@@ -1,0 +1,63 @@
+.TH RPM_FILTER.CONF: "5" "January 2023" "Red Hat" "System Administration Utilities"
+.SH NAME
+rpm-filter.conf \- fapolicyd filter configuration file
+.SH DESCRIPTION
+The file
+.I /etc/fapolicyd/rpm-filter.conf
+contains configuration of the filter for the application allowlisting daemon. This filter specifies an allow or exclude list of files from rpm. Valid line starts with character '+', '-' or '#' for comments. The rest of the line contains a path specification. Space can be used as indentation to add more specific filters to the previous one. Note, that only one space is required for one level of an indent. If  there are multiple specifications on the same indentation level they extend the previous line with lower indentation, usually a directory.  The path may be specified using the glob pattern. A directory specification has to end with a slash ‘/’.
+
+The filters are processed as follows: Starting from the up the to bottom while in case of a match the result (+/-) is set unless there is an indented block which describes more detailed specification of the parent level match. The same processing logic is applied to the inner filters definitions. If there is no match, the parent’s result is set. If there is no match at all, the default result is minus (-).
+
+If the result was a plus (+), the respective file from the rpmdb is imported to the TrustDB. Vice versa, if the result was a minus (-), the respective file is not imported.
+
+From a performance point of view it is better to design an indented filter because in the ideal situation each component of the path is compared only once. In contrast to it, a filter without any indentation has to contain a full path which makes the pattern more complicated and thus slower to process. The motivation behind this is to have a flexible configuration and keep the TrustDB as small as possible to make the look-ups faster.
+
+
+
+.nf
+.B # this is simple allow list
+.B - /usr/bin/some_binary1
+.B - /usr/bin/some_binary2
+.B + /
+.fi
+
+.nf
+.B # this is the same
+.B + /
+.B \ + usr/bin/
+.B \ \ - some_binary1
+.B \ \ - some_binary2
+.fi
+
+.nf
+.B # this is similar allow list with a wildcard
+.B - /usr/bin/some_binary?
+.B + /
+.fi
+
+.nf
+.B # this is similar with another wildcard
+.B + /
+.B \ - usr/bin/some_binary*
+.fi
+
+.nf
+.B # keeps everything except usr/share except python and perl files
+.B # /usr/bin/ls - result is '+'
+.B # /usr/share/something - result is '-'
+.B # /usr/share/abcd.py - result is '+'
+.B + /
+.B \ - usr/share/
+.B \ \ + *.py
+.B \ \ + *.pl
+.fi
+
+.SH "SEE ALSO"
+.BR fapolicyd (8),
+.BR fapolicyd-cli (1)
+.BR fapolicy.rules (5)
+and
+.BR glob (7)
+
+.SH AUTHOR
+Radovan Sroka

--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -114,6 +114,7 @@ fi
 %attr(644,root,root) %{_sysconfdir}/bash_completion.d/*
 %ghost %{_sysconfdir}/%{name}/rules.d/*
 %config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/%{name}.conf
+%config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/rpm-filter.conf
 %config(noreplace) %attr(644,root,%{name}) %{_sysconfdir}/%{name}/%{name}.trust
 %ghost %attr(644,root,%{name}) %{_sysconfdir}/%{name}/fapolicyd.rules
 %ghost %attr(644,root,%{name}) %{_sysconfdir}/%{name}/compiled.rules

--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -1,6 +1,7 @@
 EXTRA_DIST = \
 	fapolicyd.service \
 	fapolicyd.conf \
+	rpm-filter.conf \
 	fapolicyd.trust \
 	fapolicyd-tmpfiles.conf \
 	fapolicyd-magic \
@@ -11,6 +12,7 @@ fapolicyddir = $(sysconfdir)/fapolicyd
 
 dist_fapolicyd_DATA = \
 	fapolicyd.conf \
+	rpm-filter.conf \
 	fapolicyd.trust
 
 systemdservicedir = $(systemdsystemunitdir)

--- a/init/rpm-filter.conf
+++ b/init/rpm-filter.conf
@@ -1,0 +1,42 @@
+# default filter file for fedora
+
++ /
+ - usr/include/
+ - usr/share/
+  # Python byte code
+  + *.py?
+  # Python text files
+  + *.py
+  # Some apps have a private libexec
+  + */libexec/*
+  # Ruby
+  + *.rb
+  # Perl
+  + *.pl
+  # System tap
+  + *.stp
+  # Javascript
+  + *.js
+  # Java archive
+  + *.jar
+  # M4
+  + *.m4
+  # PHP
+  + *.php
+  # Perl Modules
+  + *.pm
+  # Lua
+  + *.lua
+  # Java
+  + *.class
+  # Typescript
+  + *.ts
+  # Typescript JSX
+  + *.tsx
+  # Lisp
+  + *.el
+  # Compiled Lisp
+  + *.elc
+ - usr/src/kernel*/
+  + */scripts/*
+  + */tools/objtool/*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,13 +62,19 @@ libfapolicyd_la_SOURCES = \
 	library/subject-attr.h \
 	library/subject.c \
 	library/subject.h \
+	library/stack.c \
+	library/stack.h \
 	library/string-util.c \
 	library/string-util.h \
 	library/trust-file.c \
 	library/trust-file.h
 
 if WITH_RPM
-libfapolicyd_la_SOURCES += library/rpm-backend.c
+libfapolicyd_la_SOURCES += \
+	library/rpm-backend.c \
+	library/rpm-filter.c \
+	library/rpm-filter.h
+
 endif
 
 libfapolicyd_la_CFLAGS = $(fapolicyd_CFLAGS)

--- a/src/library/llist.c
+++ b/src/library/llist.c
@@ -45,18 +45,35 @@ list_item_t *list_get_first(const list_t *list)
 	return list->first;
 }
 
-
-int list_append(list_t *list, const char *index, const char *data)
+static list_item_t * create_item(const char *index, const char *data)
 {
 	list_item_t *item = malloc(sizeof(list_item_t));
 	if (!item) {
 		msg(LOG_ERR, "Malloc failed");
-		return 1;
+		return item;
 	}
 
 	item->index = index;
 	item->data = data;
 	item->next = NULL;
+
+	return item;
+}
+
+int list_prepend(list_t *list, const char *index, const char *data)
+{
+	list_item_t *item = create_item(index, data);
+
+	item->next = list->first;
+	list->first = item;
+
+	++list->count;
+	return 0;
+}
+
+int list_append(list_t *list, const char *index, const char *data)
+{
+	list_item_t *item = create_item(index, data);
 
 	if (list->first) {
 		list->last->next = item;

--- a/src/library/llist.h
+++ b/src/library/llist.h
@@ -40,6 +40,7 @@ typedef struct list_header {
 
 void list_init(list_t *list);
 list_item_t *list_get_first(const list_t *list);
+int list_prepend(list_t *list, const char *index, const char *data);
 int list_append(list_t *list, const char *index, const char *data);
 void list_destroy_item(list_item_t **item);
 void list_empty(list_t *list);

--- a/src/library/rpm-filter.c
+++ b/src/library/rpm-filter.c
@@ -1,0 +1,487 @@
+/*
+* rpm-filter.c - filter for rpm trust source
+* Copyright (c) 2023 Red Hat Inc., Durham, North Carolina.
+* All Rights Reserved.
+*
+* This software may be freely redistributed and/or modified under the
+* terms of the GNU General Public License as published by the Free
+* Software Foundation; either version 2, or (at your option) any
+* later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; see the file COPYING. If not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+* Boston, MA 02110-1335, USA.
+*
+* Authors:
+*   Radovan Sroka <rsroka@redhat.com>
+*/
+
+#include "rpm-filter.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <fnmatch.h>
+
+#include "llist.h"
+#include "stack.h"
+#include "message.h"
+#include "string-util.h"
+
+
+#define RPM_FILTER_FILE "/etc/fapolicyd/rpm-filter.conf"
+
+rpm_filter_t *global_filter = NULL;
+
+static rpm_filter_t *filter_create_obj(void);
+static void filter_destroy_obj(rpm_filter_t *_filter);
+
+// init fuction of this module
+int filter_init(void)
+{
+	global_filter = filter_create_obj();
+	if (global_filter == NULL)
+		return 1;
+
+	return 0;
+}
+
+// destroy funtion of this module
+void filter_destroy(void)
+{
+	filter_destroy_obj(global_filter);
+	global_filter = NULL;
+}
+
+// alocate new filter object and fill with the defaults
+static rpm_filter_t *filter_create_obj(void)
+{
+	rpm_filter_t *filter = malloc(sizeof(rpm_filter_t));
+	if (filter) {
+		filter->type = NONE;
+		filter->path = NULL;
+		filter->len = 0;
+		filter->matched = 0;
+		filter->processed = 0;
+		list_init(&filter->list);
+	}
+	return filter;
+}
+
+// free all nested filters
+static void filter_destroy_obj(rpm_filter_t *_filter)
+{
+	if (_filter == NULL)
+		return;
+
+	rpm_filter_t *filter = _filter;
+	stack_t stack;
+	stack_init(&stack);
+
+	stack_push(&stack, filter);
+
+	while (!stack_is_empty(&stack)) {
+		filter = (rpm_filter_t*)stack_top(&stack);
+		if (filter->processed) {
+			(void)free(filter->path);
+			// asume that item->data is NULL
+			list_empty(&filter->list);
+			(void)free(filter);
+			stack_pop(&stack);
+			continue;
+		}
+
+		list_item_t *item = list_get_first(&filter->list);
+		for (; item != NULL ; item = item->next) {
+				rpm_filter_t *next_filter = (rpm_filter_t*)item->data;
+				// we can use list_empty() later
+				// we dont want to free filter right now
+				// it will freed after popping
+				item->data = NULL;
+				stack_push(&stack, next_filter);
+		}
+		filter->processed = 1;
+	}
+	stack_destroy(&stack);
+}
+
+// create struct and push it to the top of stack
+static void stack_push_vars(stack_t *_stack, int _level, int _offset, rpm_filter_t *_filter)
+{
+	if (_stack == NULL)
+		return;
+
+	stack_item_t *item = malloc(sizeof(stack_item_t));
+	if (item == NULL)
+		return;
+
+	item->level = _level;
+	item->offset = _offset;
+	item->filter = _filter;
+
+	stack_push(_stack, item);
+}
+
+// pop stack_item_t and free it
+static void stack_pop_vars(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return;
+
+	stack_item_t * item = (stack_item_t*)stack_top(_stack);
+	free(item);
+	stack_pop(_stack);
+}
+
+// pop all the stack_item_t and free them
+static void stack_pop_all_vars(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return;
+
+	while (!stack_is_empty(_stack))
+		stack_pop_vars(_stack);
+}
+
+// reset filter to default, pop top and free
+static void stack_pop_reset(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return;
+
+	stack_item_t *stack_item = (stack_item_t*)stack_top(_stack);
+	if (stack_item) {
+		stack_item->filter->matched = 0;
+		stack_item->filter->processed = 0;
+	}
+	free(stack_item);
+	stack_pop(_stack);
+}
+
+// reset and pop all the stack_item_t
+static void stack_pop_all_reset(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return;
+
+	while (!stack_is_empty(_stack))
+		stack_pop_reset(_stack);
+}
+
+// this funtion gets full path and checks it against filter
+// returns 1 for keeping the file and 0 for dropping it
+int filter_check(const char *_path)
+{
+	if (_path == NULL) {
+		msg(LOG_ERR, "filter_check: path is NULL, something is wrong!");
+		return 0;
+	}
+
+	rpm_filter_t *filter = global_filter;
+	char *path = strdup(_path);
+	size_t path_len = strlen(_path);
+	size_t offset = 0;
+	// Create a stack to store the filters that need to be checked
+	stack_t stack;
+	stack_init(&stack);
+
+	int res = 0;
+	int level = 0;
+
+	stack_push_vars(&stack, level, offset, filter);
+
+	while(!stack_is_empty(&stack)) {
+		int matched = 0;
+		filter->processed = 1;
+
+		// this is starting branch of the algo
+		// assuming that in root filter filter->path is NULL
+		if (filter->path == NULL) {
+			list_item_t *item = list_get_first(&filter->list);
+			// push all the descendants to the stack
+			for (; item != NULL ; item = item->next) {
+				rpm_filter_t *next_filter = (rpm_filter_t*)item->data;
+				stack_push_vars(&stack, level+1, offset, next_filter);
+			}
+
+		// usual branch, start with processing
+		} else {
+			// wildcard contition
+			char *is_wildcard = strpbrk(filter->path, "?*[");
+			if (is_wildcard) {
+				int count = 0;
+				char *filter_lim, *filter_old_lim;
+				filter_lim = filter_old_lim = filter->path;
+
+				char *path_lim, *path_old_lim;
+				path_lim = path_old_lim = path+offset;
+
+				// there can be wildcard in the dir name as well
+				// we need to count how many chars can be eaten by wildcard
+				while(1) {
+					filter_lim = strchr(filter_lim, '/');
+					path_lim = strchr(path_lim, '/');
+
+					if (filter_lim) {
+						count++;
+						filter_old_lim = filter_lim;
+						filter_lim++;
+					} else
+						break;
+
+					if (path_lim) {
+						path_old_lim = path_lim;
+						path_lim++;
+					} else
+						break;
+
+				}
+				// put 0 after the last /
+				char tmp = '\0';
+				if (count && *(filter_old_lim+1) == '\0') {
+					 tmp = *(path_old_lim+1);
+					*(path_old_lim+1) = '\0';
+				}
+
+				// check fnmatch
+				matched = !fnmatch(filter->path, path+offset, 0);
+
+				// and set back
+				if (count && *(filter_old_lim+1) == '\0')
+					*(path_old_lim+1) = tmp;
+
+				if (matched) {
+					offset = path_old_lim - path+offset;
+				}
+			} else {
+				// match normal path or just specific part of it
+				matched = !strncmp(path+offset, filter->path, filter->len);
+				if (matched)
+					offset += filter->len;
+			}
+
+			if (matched) {
+				level++;
+				filter->matched = 1;
+
+				// if matched we need ot push descendants to the stack
+				list_item_t *item = list_get_first(&filter->list);
+
+				// if there are no descendants and it is a wildcard then it's a match
+				if (item == NULL && is_wildcard) {
+					// if '+' ret 1 and if '-' ret 0
+					res = filter->type == ADD ? 1 : 0;
+					goto end;
+				}
+
+				// no descendants, and already compared whole path string so its a match
+				if (item == NULL && path_len == offset) {
+					// if '+' ret 1 and if '-' ret 0
+					res = filter->type == ADD ? 1 : 0;
+					goto end;
+				}
+
+				// push descendants to the stack
+				for (; item != NULL ; item = item->next) {
+					rpm_filter_t *next_filter = (rpm_filter_t*)item->data;
+					stack_push_vars(&stack, level, offset, next_filter);
+				}
+
+			}
+
+		}
+
+		stack_item_t * stack_item = NULL;
+		// popping processed filters from the top of the stack
+		do {
+			if (stack_item) {
+				filter = stack_item->filter;
+				offset = stack_item->offset;
+				level = stack_item->level;
+
+				// assuimg that nothing has matched on the upper level so it's a directory match
+				if (filter->matched && filter->path[filter->len-1] == '/') {
+					res = filter->type == ADD ? 1 : 0;
+					goto end;
+				}
+
+				// reset processed flag
+				stack_pop_reset(&stack);
+			}
+
+			stack_item = (stack_item_t*)stack_top(&stack);
+		} while(stack_item && stack_item->filter->processed);
+
+		if (!stack_item)
+			break;
+
+		filter = stack_item->filter;
+		offset = stack_item->offset;
+		level = stack_item->level;
+	}
+
+end:
+	// Clean up the stack
+	stack_pop_all_reset(&stack);
+	stack_destroy(&stack);
+	free(path);
+	return res;
+}
+
+// load rpm filter configuration file and fill the filter structure
+int filter_load_file(void)
+{
+	int res = 0;
+	FILE *stream = fopen(RPM_FILTER_FILE, "r");
+
+	if (stream == NULL) {
+		msg(LOG_ERR, "Cannot open filter file %s", RPM_FILTER_FILE);
+		return 1;
+	}
+
+	ssize_t nread;
+	size_t len = 0;
+	char * line = NULL;
+	long line_number = 0;
+	int last_level = 0;
+
+	stack_t stack;
+	stack_init(&stack);
+	stack_push_vars(&stack, last_level, 0, global_filter);
+
+	while ((nread = getline(&line, &len, stream)) != -1) {
+		line_number++;
+
+		if (line[0] == '\0' || line[0] == '\n') {
+			free(line);
+			line = NULL;
+			continue;
+		}
+
+		// get rid of the new line char
+		char * new_line = strchr(line, '\n');
+		if (new_line) {
+			*new_line = '\0';
+			len--;
+		}
+
+		int level = 1;
+		char * rest = line;
+		rpm_filter_type_t type = NONE;
+
+		for (size_t i = 0 ; i < len ; i++) {
+			switch (line[i]) {
+				case ' ':
+					level++;
+					continue;
+				case '+':
+					type = ADD;
+					break;
+				case '-':
+					type = SUB;
+					break;
+				case '#':
+					type = COMMENT;
+					break;
+				default:
+					type = BAD;
+					break;
+			}
+
+			// continue with next char
+			// skip + and space
+			rest = fapolicyd_strtrim(&(line[i+2]));
+			break;
+		}
+
+		// ignore comment
+		if (type == COMMENT) {
+			free(line);
+			line = NULL;
+			continue;
+		}
+
+		// if something bad return error
+		if (type == BAD) {
+			msg(LOG_ERR, "filter_load_file: cannot parse line number %ld, \"%s\"", line_number, line);
+			free(line);
+			line = NULL;
+			goto bad;
+		}
+
+		rpm_filter_t * filter = filter_create_obj();
+
+		if (filter) {
+			filter->path = strdup(rest);
+			filter->len = strlen(filter->path);
+			filter->type = type;
+		}
+
+		// comparing level of indetantion between the last line and the current one
+		last_level = ((stack_item_t*)stack_top(&stack))->level;
+		if (level == last_level) {
+
+			// since we are at the same level as filter before
+			// we need to pop the previous filter from the top
+			stack_pop_vars(&stack);
+
+			// pushing filter to the list of top's children list
+			list_prepend(&((stack_item_t*)stack_top(&stack))->filter->list, NULL, (void*)filter);
+
+			// pushing filter to the top of the stack
+			stack_push_vars(&stack, level, 0, filter);
+
+		} else if (level == last_level + 1) {
+			// this filter has higher level tha privious one
+			// we wont do pop just push
+
+			// pushing filter to the list of top's children list
+			list_prepend(&((stack_item_t*)stack_top(&stack))->filter->list, NULL, (void*)filter);
+
+			// pushing filter to the top of the stack
+			stack_push_vars(&stack, level, 0, filter);
+
+		} else if (level < last_level){
+			// level of indentation dropped
+			// we need to pop
+			// +1 is meant for getting rid of the current level so we can again push
+			for (int i = 0 ; i < last_level - level + 1; i++) {
+				stack_pop_vars(&stack);
+			}
+
+			// pushing filter to the list of top's children list
+			list_prepend(&((stack_item_t*)stack_top(&stack))->filter->list, NULL, (void*)filter);
+
+			// pushing filter to the top of the stack
+			stack_push_vars(&stack, level, 0, filter);
+
+		} else {
+			msg(LOG_ERR, "filter_load_file: paring error line: %ld, \"%s\"", line_number, line);
+			filter_destroy_obj(filter);
+			free(line);
+			goto bad;
+		}
+
+		free(line);
+		line = NULL;
+	}
+
+	goto good;
+bad:
+	res = 1;
+
+good:
+	fclose(stream);
+	stack_pop_all_vars(&stack);
+	stack_destroy(&stack);
+	if (global_filter->list.count == 0) {
+		msg(LOG_ERR, "filter_load_file: no valid filter provided in %s", RPM_FILTER_FILE);
+	}
+	return res;
+}

--- a/src/library/rpm-filter.h
+++ b/src/library/rpm-filter.h
@@ -1,0 +1,67 @@
+/*
+* rpm-filter.h - Header for rpm filter implementation
+* Copyright (c) 2023 Red Hat Inc., Durham, North Carolina.
+* All Rights Reserved.
+*
+* This software may be freely redistributed and/or modified under the
+* terms of the GNU General Public License as published by the Free
+* Software Foundation; either version 2, or (at your option) any
+* later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; see the file COPYING. If not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+* Boston, MA 02110-1335, USA.
+*
+* Authors:
+*   Radovan Sroka <rsroka@redhat.com>
+*/
+
+#ifndef FILTER_H_
+#define FILTER_H_
+
+#include <stdlib.h>
+#include <stddef.h>
+
+#include "llist.h"
+
+typedef enum rpm_filter_type
+{
+	NONE,
+	ADD,
+	SUB,
+	COMMENT,
+	BAD,
+} rpm_filter_type_t;
+
+typedef struct _rpm_filter
+{
+	rpm_filter_type_t type;
+	char * path;
+	size_t len;
+	int processed;
+	int matched;
+	list_t list;
+} rpm_filter_t;
+
+
+typedef struct _stack_item
+{
+	int level;
+	int offset;
+	rpm_filter_t *filter;
+} stack_item_t;
+
+
+int filter_init(void);
+void filter_destroy(void);
+int filter_check(const char *_path);
+int filter_load_file(void);
+
+
+#endif // FILTER_H_

--- a/src/library/stack.c
+++ b/src/library/stack.c
@@ -1,0 +1,89 @@
+/*
+* stack.c - generic stack impementation
+* Copyright (c) 2023 Red Hat Inc., Durham, North Carolina.
+* All Rights Reserved.
+*
+* This software may be freely redistributed and/or modified under the
+* terms of the GNU General Public License as published by the Free
+* Software Foundation; either version 2, or (at your option) any
+* later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; see the file COPYING. If not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+* Boston, MA 02110-1335, USA.
+*
+* Authors:
+*   Radovan Sroka <rsroka@redhat.com>
+*/
+
+#include "stack.h"
+#include <stddef.h>
+
+// init of the stack struct
+void stack_init(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return;
+
+	list_init(_stack);
+}
+
+// free all the resources from the stack
+void stack_destroy(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return;
+
+	list_empty(_stack);
+}
+
+// push to the top of the stack
+void stack_push(stack_t *_stack, void *_data)
+{
+	if (_stack == NULL)
+		return;
+
+	list_prepend(_stack, NULL, (void *)_data);
+}
+
+// pop the the top without returning what was on the top
+void stack_pop(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return;
+
+	list_item_t *first = _stack->first;
+	_stack->first = first->next;
+	first->data = NULL;
+	list_destroy_item(&first);
+	_stack->count--;
+
+	return;
+}
+
+// function returns 1 if stack is emtpy 0 if it's not
+int stack_is_empty(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return -1;
+
+	if (_stack->count == 0)
+		return 1;
+
+	return 0;
+}
+
+// return top of the stack without popping
+const void *stack_top(stack_t *_stack)
+{
+	if (_stack == NULL)
+		return NULL;
+
+	return _stack->first ? _stack->first->data : NULL;
+}

--- a/src/library/stack.h
+++ b/src/library/stack.h
@@ -1,0 +1,41 @@
+/*
+* stack.h - header for generic stack implementation
+* Copyright (c) 2023 Red Hat Inc., Durham, North Carolina.
+* All Rights Reserved.
+*
+* This software may be freely redistributed and/or modified under the
+* terms of the GNU General Public License as published by the Free
+* Software Foundation; either version 2, or (at your option) any
+* later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; see the file COPYING. If not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+* Boston, MA 02110-1335, USA.
+*
+* Authors:
+*   Radovan Sroka <rsroka@redhat.com>
+*/
+
+
+#ifndef STACK_H_
+#define STACK_H_
+
+#include "llist.h"
+
+typedef list_t stack_t;
+
+void stack_init(stack_t *_stack);
+void stack_destroy(stack_t *_stack);
+void stack_push(stack_t *_stack, void *_data);
+void stack_pop(stack_t *_stack);
+int stack_is_empty(stack_t *_stack);
+const void *stack_top(stack_t *_stack);
+
+
+#endif // STACK_H_


### PR DESCRIPTION
- this feature introduces very flexible filter syntax
- original filter was compiled in so this is very useful
- filter needs to keep a minimal set of files that will be excuted on the system eventually
- all the configuration can be done in /etc/fapolicyd/rpm-filter.conf

Signed-off-by: Radovan Sroka <rsroka@redhat.com>