### PR TITLE
Move manpage for fapolicyd-cli from section 1 to 8

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,7 +25,7 @@ EXTRA_DIST = $(man_MANS)
 man_MANS = \
 	fapolicyd.8 \
 	fagenrules.8 \
-	fapolicyd-cli.1 \
+	fapolicyd-cli.8 \
 	fapolicyd.rules.5 \
 	fapolicyd.trust.5 \
 	fapolicyd.conf.5 \

--- a/doc/fagenrules.8
+++ b/doc/fagenrules.8
@@ -28,5 +28,5 @@ load old or newly built rules into the daemon.
 /etc/fapolicyd/compiled.rules
 .SH "SEE ALSO"
 .BR fapolicyd.rules (5),
-.BR fapolicyd-cli (1),
+.BR fapolicyd-cli (8),
 .BR fapolicyd (8).

--- a/doc/fapolicyd-cli.8
+++ b/doc/fapolicyd-cli.8
@@ -1,4 +1,4 @@
-.TH "FAPOLICYD-CLI" "1" "Dec 2021" "Red Hat" "System Administration Utilities"
+.TH "FAPOLICYD-CLI" "8" "Dec 2021" "Red Hat" "System Administration Utilities"
 .SH NAME
 fapolicyd-cli \- Fapolicyd CLI Tool
 .SH SYNOPSIS

--- a/doc/fapolicyd.8
+++ b/doc/fapolicyd.8
@@ -87,7 +87,7 @@ If you are running in the debug mode and wish to compare rule numbers reported i
 - internal performance metrics
 
 .SH "SEE ALSO"
-.BR fapolicyd-cli (1),
+.BR fapolicyd-cli (8),
 .BR fapolicyd.rules (5),
 .BR fapolicyd.trust (5),
 .BR fagenrules (8),

--- a/doc/fapolicyd.conf.5
+++ b/doc/fapolicyd.conf.5
@@ -93,7 +93,7 @@ When this option is set to 1, it allows fapolicyd to monitor file access events 
 
 .SH "SEE ALSO"
 .BR fapolicyd (8),
-.BR fapolicyd-cli (1)
+.BR fapolicyd-cli (8)
 and
 .BR fapolicy.rules (5).
 

--- a/doc/fapolicyd.rules.5
+++ b/doc/fapolicyd.rules.5
@@ -196,7 +196,7 @@ The following rules illustrate the rule syntax.
 .SH "SEE ALSO"
 .BR fapolicyd (8),
 .B fagenrules (8),
-.BR fapolicyd-cli (1),
+.BR fapolicyd-cli (8),
 and
 .BR fapolicyd.conf (5)
 

--- a/doc/fapolicyd.trust.5
+++ b/doc/fapolicyd.trust.5
@@ -28,7 +28,7 @@ Trust files can either be created manually inside \fBtrust\&.d\fR directory or v
 
 .SH "SEE ALSO"
 .BR fapolicyd (8),
-.BR fapolicyd-cli (1)
+.BR fapolicyd-cli (8)
 .BR fapolicy.rules (5)
 and
 .BR fapolicy.conf (5).

--- a/init/fapolicyd.bash_completion
+++ b/init/fapolicyd.bash_completion
@@ -1,4 +1,4 @@
-# fapolicyd-cli(1) completion                             -*- shell-script -*-
+# fapolicyd-cli (8) completion                             -*- shell-script -*-
 
 _fapolicydcli()
 {


### PR DESCRIPTION
Hi,

Lintian reports manual-page-for-system-command [0] regarding fapolicyd-cli, which means we should move that command from sbin to bin, or alternatively move its manual page from section 1 to section 8.

According to a document [1], fapolicyd-cli is expected to run with root privilege, so fapolicyd-cli is considered to be usually useful for privileged users.
As such, the manpage of the command should be moved from section 1 to section 8.

If things are satisfactory, please consider applying this patch.

Regards,
Fukui

[0] https://lintian.debian.org/tags/manual-page-for-system-command

[1] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_blocking-and-allowing-applications-using-fapolicyd_security-hardening#introduction-to-fapolicyd_assembly_blocking-and-allowing-applications-using-fapolicyd