### PR TITLE
Initial debdb implementation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,18 @@ if test x$use_rpm = xyes ; then
 fi
 AM_CONDITIONAL(WITH_RPM, test x$use_rpm = xyes)
 
+# TODO default deb to be disabled.
+withval=""
+AC_ARG_WITH(deb,
+AS_HELP_STRING([--with-deb],[Use the deb database as a trust source]),
+use_deb=$withval,use_deb=yes)
+
+if test x$use_deb = xyes ; then
+    AC_CHECK_LIB(dpkg, pkg_array_init_from_hash, , [AC_MSG_ERROR([libdpkg not found])], -ldpkg)
+    AC_DEFINE(USE_DEB,1,[Define if you want to use the deb database as trust source.])
+fi
+AM_CONDITIONAL(WITH_DEB, test x$use_deb = xyes)
+
 dnl FIXME some day pass this on the command line
 def_systemdsystemunitdir=${prefix}/lib/systemd/system
 AC_SUBST([systemdsystemunitdir], [$def_systemdsystemunitdir])

--- a/configure.ac
+++ b/configure.ac
@@ -75,11 +75,10 @@ if test x$use_rpm = xyes ; then
 fi
 AM_CONDITIONAL(WITH_RPM, test x$use_rpm = xyes)
 
-# TODO default deb to be disabled.
 withval=""
 AC_ARG_WITH(deb,
 AS_HELP_STRING([--with-deb],[Use the deb database as a trust source]),
-use_deb=$withval,use_deb=yes)
+use_deb=$withval,use_deb=no)
 
 if test x$use_deb = xyes ; then
     AC_CHECK_LIB(dpkg, pkg_array_init_from_hash, , [AC_MSG_ERROR([libdpkg not found])], -ldpkg)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,9 +11,6 @@ lib_LTLIBRARIES= libfapolicyd.la
 fapolicyd_CFLAGS = -fPIE -DPIE -pthread -g -W -Wall -Wshadow -Wundef -Wno-unused-result -Wno-unused-parameter -D_GNU_SOURCE
 fapolicyd_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
 
-fapolicyd_cli_CFLAGS = $(fapolicyd_CFLAGS)
-fapolicyd_cli_LDFLAGS = $(fapolicyd_LDFLAGS)
-
 libfapolicyd_la_SOURCES = \
 	library/avl.c \
 	library/avl.h \
@@ -76,6 +73,15 @@ libfapolicyd_la_SOURCES += \
 	library/rpm-filter.h
 
 endif
+
+if WITH_DEB
+libfapolicyd_la_SOURCES += library/deb-backend.c
+fapolicyd_CFLAGS += -DLIBDPKG_VOLATILE_API
+fapolicyd_LDFLAGS += -ldpkg
+endif
+
+fapolicyd_cli_CFLAGS = $(fapolicyd_CFLAGS)
+fapolicyd_cli_LDFLAGS = $(fapolicyd_LDFLAGS)
 
 libfapolicyd_la_CFLAGS = $(fapolicyd_CFLAGS)
 libfapolicyd_la_LDFLAGS = $(fapolicyd_LDFLAGS) -lpthread

--- a/src/cli/fapolicyd-cli.c
+++ b/src/cli/fapolicyd-cli.c
@@ -648,7 +648,7 @@ static int verify_file(const char *path, off_t size, const char *sha)
 	if (sb.st_size != size)
 		warn_size = 1;
 
-	char *sha_buf = get_hash_from_fd2(fd, sb.st_size);
+	char *sha_buf = get_hash_from_fd2(fd, sb.st_size, 1);
 	close(fd);
 
 	if (sha_buf == NULL || strcmp(sha, sha_buf))

--- a/src/library/backend-manager.c
+++ b/src/library/backend-manager.c
@@ -36,6 +36,8 @@
 extern backend file_backend;
 #ifdef USE_RPM
 extern backend rpm_backend;
+#elif USE_DEB
+extern backend deb_backend;
 #endif
 
 static backend* compiled[] =
@@ -43,6 +45,8 @@ static backend* compiled[] =
 	&file_backend,
 #ifdef USE_RPM
 	&rpm_backend,
+#elif USE_DEB
+	&deb_backend,
 #endif
 	NULL,
 };

--- a/src/library/database.c
+++ b/src/library/database.c
@@ -995,7 +995,7 @@ retry_res:
 
 			// Calculate a hash only one time
 			if (retry == 1) {
-				hash = get_hash_from_fd2(fd, info->size);
+				hash = get_hash_from_fd2(fd, info->size, 1);
 				if (hash) {
 					strncpy(sha_xattr, hash, 64);
 					sha_xattr[64] = 0;

--- a/src/library/deb-backend.c
+++ b/src/library/deb-backend.c
@@ -1,0 +1,298 @@
+#include <dpkg/db-ctrl.h>
+#include <dpkg/db-fsys.h>
+#include <dpkg/pkg-array.h>
+#include <dpkg/program.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <uthash.h>
+
+#include "conf.h"
+#include "fapolicyd-backend.h"
+#include "file.h"
+#include "llist.h"
+#include "message.h"
+
+static const char kDebBackend[] = "debdb";
+const int kMaxKeyLength = 4096;
+const int kMd5HexSize = 32;
+
+static int deb_init_backend(void);
+static int deb_load_list(const conf_t *);
+static int deb_destroy_backend(void);
+
+backend deb_backend = {
+    kDebBackend,
+    deb_init_backend,
+    deb_load_list,
+    deb_destroy_backend,
+    /* list initialization */
+    {0, 0, NULL},
+};
+
+struct _hash_record {
+  const char *key;
+  UT_hash_handle hh;
+};
+
+/*
+ * Given a path to a file with an expected MD5 digest, add
+ * the file to the trust database if it matches.
+ *
+ * Dpkg does not provide sha256 sums or file sizes to verify against.
+ * The only source for verification is MD5. The logic implemented is:
+ * 1) Calculate the MD5 sum and compare to the dpkg database. If it does
+ *    not match, abort.
+ * 2) Calculate the SHA256 and file size on the local files.
+ * 3) Add to database.
+ *
+ * Security considerations:
+ * An attacker would need to craft a file with a MD5 hash collision.
+ * While MD5 is considered broken, this is still some effort.
+ * This function would compute a sha256 and file size on the attackers
+ * crafted file so they do not secure this backend.
+ */
+static int add_file_to_backend(const char *path,
+                               struct _hash_record **hashtable,
+                               const char *expected_md5) {
+  struct stat path_stat;
+  stat(path, &path_stat);
+
+  // If its not a regular file, skip.
+  if (!S_ISREG(path_stat.st_mode)) {
+    msg(LOG_DEBUG, "\nNot regular file %s", path);
+    return 1;
+  }
+
+  // Open the file and calculate sha256 and size.
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    msg(LOG_WARNING, "\nCould not open %s", path);
+    return 1;
+  }
+  size_t file_size = lseek(fd, 0, SEEK_END);
+  lseek(fd, 0, SEEK_SET);
+  char *sha_digest = get_hash_from_fd2(fd, file_size, 1);
+
+  if (sha_digest == NULL) {
+    msg(LOG_ERR, "\nSha digest returned NULL");
+    return 1;
+  }
+
+  lseek(fd, 0, SEEK_SET);
+  char *md5_digest = get_hash_from_fd2(fd, file_size, 0);
+
+  if (md5_digest == NULL) {
+    free(sha_digest);
+    msg(LOG_ERR, "\nMD5 digest returned NULL");
+    return 1;
+  }
+
+  close(fd);
+
+  if (strcmp(md5_digest, expected_md5) != 0) {
+    msg(LOG_WARNING, "\nSkipping %s as hash mismatched. Should be %s, got %s",
+        path, expected_md5, md5_digest);
+    free(sha_digest);
+    free(md5_digest);
+    return 1;
+  }
+  free(md5_digest);
+
+  char *data;
+  if (asprintf(&data, DATA_FORMAT, SRC_DEB, file_size, sha_digest) == -1) {
+    data = NULL;
+  }
+  free(sha_digest);
+
+  if (data) {
+    // Getting rid of the duplicates.
+    struct _hash_record *rcd = NULL;
+    char key[kMaxKeyLength];
+    snprintf(key, kMaxKeyLength - 1, "%s %s", path, data);
+
+    HASH_FIND_STR(*hashtable, key, rcd);
+
+    if (!rcd) {
+      rcd = (struct _hash_record *)malloc(sizeof(struct _hash_record));
+      rcd->key = strdup(key);
+      HASH_ADD_KEYPTR(hh, *hashtable, rcd->key, strlen(rcd->key), rcd);
+      list_append(&deb_backend.list, strdup(path), data);
+    } else {
+      free((void *)data);
+    }
+    return 0;
+  }
+  return 1;
+}
+
+// ================================================================
+// These functions are copied from dpkg source v1.21.1
+// For some reason they segfault when i call :/
+
+parse_filehash_buffer(struct varbuf *buf, struct pkginfo *pkg,
+                      struct pkgbin *pkgbin) {
+  char *thisline, *nextline;
+  const char *pkgname = pkg_name(pkg, pnaw_nonambig);
+  const char *buf_end = buf->buf + buf->used;
+
+  for (thisline = buf->buf; thisline < buf_end; thisline = nextline) {
+    struct fsys_namenode *namenode;
+    char *endline, *hash_end, *filename;
+
+    endline = memchr(thisline, '\n', buf_end - thisline);
+    if (endline == NULL) {
+      msg(LOG_ERR,
+          "control file '%s' for package '%s' is "
+          "missing final newline\n",
+          HASHFILE, pkgname);
+      return 1;
+    }
+
+    /* The md5sum hash has a constant length. */
+    hash_end = thisline + kMd5HexSize;
+
+    filename = hash_end + 2;
+    if (filename + 1 > endline) {
+      msg(LOG_ERR,
+          "control file '%s' for package '%s' is "
+          "missing value\n",
+          HASHFILE, pkgname);
+      return 1;
+    }
+
+    if (hash_end[0] != ' ' || hash_end[1] != ' ') {
+      msg(LOG_ERR,
+          "control file '%s' for package '%s' is "
+          "missing value separator\n",
+          HASHFILE, pkgname);
+      return 1;
+    }
+    hash_end[0] = '\0';
+
+    /* Where to start next time around. */
+    nextline = endline + 1;
+    /* Strip trailing ‘/’. */
+    if (endline > thisline && endline[-1] == '/') endline--;
+    *endline = '\0';
+
+    if (endline == thisline) {
+      msg(LOG_ERR,
+          "control file '%s' for package '%s' "
+          "contains empty filename\n",
+          HASHFILE, pkgname);
+      return 1;
+    }
+
+    /* Add the file to the list. */
+    namenode = fsys_hash_find_node(filename, 0);
+    namenode->newhash = nfstrsave(thisline);
+  }
+}
+
+void parse_filehash2(struct pkginfo *pkg, struct pkgbin *pkgbin) {
+  const char *hashfile;
+  struct varbuf buf = VARBUF_INIT;
+  struct dpkg_error err = DPKG_ERROR_INIT;
+
+  hashfile = pkg_infodb_get_file(pkg, pkgbin, HASHFILE);
+
+  if (file_slurp(hashfile, &buf, &err) < 0 && err.syserrno != ENOENT)
+    msg(LOG_ERR, "loading control file '%s' for package '%s'", HASHFILE,
+        pkg_name(pkg, pnaw_nonambig));
+
+  if (buf.used > 0) parse_filehash_buffer(&buf, pkg, pkgbin);
+
+  varbuf_destroy(&buf);
+}
+
+// End of functions copied from dpkg.
+// =======================================================================
+
+static int deb_load_list(const conf_t *conf) {
+  const char *control_file = "md5sums";
+
+  list_empty(&deb_backend.list);
+  struct _hash_record *hashtable = NULL;
+  struct _hash_record **hashtable_ptr = &hashtable;
+
+  struct pkg_array array;
+  pkg_array_init_from_hash(&array);
+
+  msg(LOG_INFO, "Computing hashes for %d packages.", array.n_pkgs);
+
+  for (int i = 0; i < array.n_pkgs; i++) {
+    struct pkginfo *package = array.pkgs[i];
+    if (package->status != PKG_STAT_INSTALLED) {
+      continue;
+    }
+    printf("\x1b[2K\rPackage %d / %d : %s", i + 1, array.n_pkgs,
+           package->set->name);
+    if (pkg_infodb_has_file(package, &package->installed, control_file))
+      pkg_infodb_get_file(package, &package->installed, control_file);
+    ensure_packagefiles_available(package);
+
+    // Should not need this copy of code ...
+    parse_filehash2(package, &package->installed);
+
+    // This is causing segfault in linked lib :/
+    // parse_filehash(package, &package->installed);
+    // ensure_diversions();
+
+    struct fsys_namenode_list *file = package->files;
+    if (!file) {
+      // Package does not have any files.
+      continue;
+    }
+    // Loop over all files in the package, adding them to debdb.
+    while (file) {
+      struct fsys_namenode *namenode = file->namenode;
+      // Get the hash and path of the file.
+      const char *hash =
+          (namenode->newhash == NULL) ? namenode->oldhash : namenode->newhash;
+      const char *path = (namenode->divert && !namenode->divert->camefrom)
+                             ? namenode->divert->useinstead->name
+                             : namenode->name;
+      if (hash != NULL) {
+        add_file_to_backend(path, hashtable_ptr, hash);
+      }
+      file = file->next;
+    }
+  }
+
+  struct _hash_record *item, *tmp;
+  HASH_ITER(hh, hashtable, item, tmp) {
+    HASH_DEL(hashtable, item);
+    free((void *)item->key);
+    free((void *)item);
+  }
+
+  pkg_array_destroy(&array);
+  return 0;
+}
+
+static int deb_init_backend() {
+  dpkg_program_init(kDebBackend);
+  list_init(&deb_backend.list);
+
+  msg(LOG_INFO, "Loading debdb backend");
+
+  enum modstatdb_rw status = msdbrw_readonly;
+  status = modstatdb_open(msdbrw_readonly);
+  if (status != msdbrw_readonly) {
+    msg(LOG_ERR, "Could not open database for reading. Status %d", status);
+    return 1;
+  }
+
+  return 0;
+}
+
+static int deb_destroy_backend() {
+  dpkg_program_done();
+  list_empty(&deb_backend.list);
+  modstatdb_shutdown();
+  return 0;
+}

--- a/src/library/event.c
+++ b/src/library/event.c
@@ -454,7 +454,7 @@ object_attr_t *get_obj_attr(event_t *e, object_type_t t)
 			}
 			break;
 		case SHA256HASH:
-			obj.o = get_hash_from_fd2(e->fd, o->info->size);
+			obj.o = get_hash_from_fd2(e->fd, o->info->size, 1);
 			break;
 		case OBJ_TRUST: {
 			object_attr_t *path =  get_obj_attr(e, PATH);

--- a/src/library/fapolicyd-backend.h
+++ b/src/library/fapolicyd-backend.h
@@ -28,7 +28,7 @@
 #include "conf.h"
 #include "llist.h"
 
-typedef enum { SRC_UNKNOWN, SRC_RPM, SRC_FILE_DB } trust_src_t;
+typedef enum { SRC_UNKNOWN, SRC_RPM, SRC_DEB, SRC_FILE_DB } trust_src_t;
 
 // source, size, sha
 #define DATA_FORMAT "%u %lu %64s"

--- a/src/library/file.c
+++ b/src/library/file.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <openssl/sha.h>
+#include <openssl/md5.h>
 #include <magic.h>
 #include <libudev.h>
 #include <elf.h>

--- a/src/library/file.h
+++ b/src/library/file.h
@@ -58,7 +58,7 @@ char *get_file_type_from_fd(int fd, const struct file_info *i, const char *path,
 	__attr_access ((__write_only__, 5, 4));
 char *bytes2hex(char *final, const unsigned char *buf, unsigned int size)
 	__attr_access ((__read_only__, 2, 3));
-char *get_hash_from_fd2(int fd, size_t size) MALLOCLIKE;
+char *get_hash_from_fd2(int fd, size_t size, int is_sha) MALLOCLIKE;
 int get_ima_hash(int fd, char *sha);
 uint32_t gather_elf(int fd, off_t size);
 

--- a/src/library/trust-file.c
+++ b/src/library/trust-file.c
@@ -84,7 +84,7 @@ static char *make_data_string(const char *path)
 	}
 
 	// Get the hash
-	char *hash = get_hash_from_fd2(fd, sb.st_size);
+	char *hash = get_hash_from_fd2(fd, sb.st_size, 1);
 	close(fd);
 	if (!hash) {
 		msg(LOG_ERR, "Cannot hash %s", path);

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -20,8 +20,7 @@
 #
 
 CONFIG_CLEAN_FILES = *.orig *.cur
-check_PROGRAMS = avl_test gid_proc_test deb_test
-TESTS = $(check_PROGRAMS)
+check_PROGRAMS = avl_test gid_proc_test
 
 AM_CPPFLAGS = -I${top_srcdir}/src/library/
 
@@ -29,6 +28,8 @@ avl_test_SOURCES = avl_test.c ${top_srcdir}/src/library/avl.c
 gid_proc_test_SOURCES = gid_proc_test.c 
 gid_proc_test_LDADD = ${top_builddir}/src/.libs/libfapolicyd.la
 
+if WITH_DEB
+check_PROGRAMS += deb_test
 deb_test_CFLAGS = -fPIE -DPIE -pthread -g -W -Wall -Wshadow -Wundef -Wno-unused-result -Wno-unused-parameter -D_GNU_SOURCE -DLIBDPKG_VOLATILE_API
 deb_test_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now,-ldpkg
 
@@ -38,3 +39,6 @@ deb_test_SOURCES = \
   ${top_srcdir}/src/library/file.c \
   ${top_srcdir}/src/library/backend-manager.c \
   ${top_srcdir}/src/library/deb-backend.c
+endif
+
+TESTS = $(check_PROGRAMS)

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -20,7 +20,7 @@
 #
 
 CONFIG_CLEAN_FILES = *.orig *.cur
-check_PROGRAMS = avl_test gid_proc_test
+check_PROGRAMS = avl_test gid_proc_test deb_test
 TESTS = $(check_PROGRAMS)
 
 AM_CPPFLAGS = -I${top_srcdir}/src/library/
@@ -29,3 +29,12 @@ avl_test_SOURCES = avl_test.c ${top_srcdir}/src/library/avl.c
 gid_proc_test_SOURCES = gid_proc_test.c 
 gid_proc_test_LDADD = ${top_builddir}/src/.libs/libfapolicyd.la
 
+deb_test_CFLAGS = -fPIE -DPIE -pthread -g -W -Wall -Wshadow -Wundef -Wno-unused-result -Wno-unused-parameter -D_GNU_SOURCE -DLIBDPKG_VOLATILE_API
+deb_test_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now,-ldpkg
+
+deb_test_LDADD = ${top_builddir}/src/.libs/libfapolicyd.la
+deb_test_SOURCES = \
+  deb_test.c \
+  ${top_srcdir}/src/library/file.c \
+  ${top_srcdir}/src/library/backend-manager.c \
+  ${top_srcdir}/src/library/deb-backend.c

--- a/src/tests/deb_test.c
+++ b/src/tests/deb_test.c
@@ -1,0 +1,36 @@
+#include <stddef.h>
+#include <string.h>
+
+#include "backend-manager.h"
+#include "conf.h"
+#include "config.h"
+#include "message.h"
+
+int main(int argc, char* const argv[]) {
+  set_message_mode(MSG_STDERR, DBG_YES);
+
+  conf_t conf;
+  conf.trust = "debdb";
+  backend_init(&conf);
+  backend_load(&conf);
+
+  msg(LOG_INFO, "\nDone loading.");
+
+  backend_entry* debdb_entry = backend_get_first();
+  backend* debdb = NULL;
+  if (debdb_entry != NULL) {
+    debdb = debdb_entry->backend;
+  } else {
+    msg(LOG_ERR, "ERROR: No backends registered.");
+  }
+  if (debdb == NULL) {
+    msg(LOG_ERR, "ERROR: debdb not registered");
+  }
+  if (strcmp(conf.trust, debdb->name) != 0) {
+    msg(LOG_ERR, "ERROR: debdb bad name");
+  }
+
+  backend_close();
+
+  return 0;
+}


### PR DESCRIPTION
This allows fapolicyd to read the md5 hashes from dpkg as a trust source. Add a deb_test binary to run the backend standalone for debugging.

Fixes #218 

The approach used is to look at the md5 hashes from dpkg, verify they match then compute the sha256sum on the files again. This means fapolicyd is still using sha256 internally/everywhere else.

Unfortunately this means when running with `debdb` backend, this is only going to be secured with md5 which is still better than nothing.

This is still a WIP. See the TODOs.
