### PR TITLE
Changed case from 'Fapolicyd' to 'fapolicyd' + fixed a typo in manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ an option if performance is problematic.
 
 MEMORY USAGE
 ------------
-Fapolicyd uses lmdb as its trust database. The database has very fast
+fapolicyd uses lmdb as its trust database. The database has very fast
 performance because it uses the kernel virtual memory system to put the
 whole database in memory. If the database is sized wrongly, then fapolicyd
 will reserve too much memory. Don't worry too much about this. The kernel is
@@ -433,7 +433,7 @@ Starting with 1.1, fapolicyd-cli includes some diagnostic capabilities.
 
 MANAGING TRUST
 --------------
-Fapolicyd use lmdb as a backend database for its trusted software list. You
+fapolicyd use lmdb as a backend database for its trusted software list. You
 can find this database in /var/lib/fapolicyd/. This list gets updated
 whenever packages are installed by dnf by a dnf plugin. If packages are
 installed by rpm instead of dnf, fapolicyd does not get a notification. In
@@ -506,7 +506,7 @@ file. Just add the places where libraries and applications are stored.
 SE Linux is modeling how an application behaves. It is not concerned about
 where the application came from or whether it's known to the system. Basically,
 anything in /bin gets bin_t type by default which is not a very restrictive
-label. MAC systems serve a different purpose. Fapolicyd by design cares solely
+label. MAC systems serve a different purpose. fapolicyd by design cares solely
 about if this is a known application/library. These are complimentary security
 subsystems. There is more information about application whitelisting use cases
 at the following NIST website:

--- a/doc/fapolicyd-cli.8
+++ b/doc/fapolicyd-cli.8
@@ -1,6 +1,6 @@
 .TH "FAPOLICYD-CLI" "8" "Dec 2021" "Red Hat" "System Administration Utilities"
 .SH NAME
-fapolicyd-cli \- Fapolicyd CLI Tool
+fapolicyd-cli \- fapolicyd CLI Tool
 .SH SYNOPSIS
 \fBfapolicyd-cli\fP [\fIoptions\fP]
 .SH DESCRIPTION
@@ -49,7 +49,7 @@ This command updates the size and hash of any matching paths in the file trust d
 Use after \fBfile\fP option. Makes every command of \fBfile\fP option operate on a single trust file named \fBtrust-file-name\fP that is located inside trust.d directory. If a trust file with such a name does not exist inside trust.d directory, it is created.
 .TP
 .B \-t, \-\-ftype /path/to/file
-Prints the mime type of the file given. A full path must be specified. This command is intended to help get the ftype parameter of rules correct by seeing how fapolicyd will classify it. Fapolicyd may differ from the \fBfile\fP command.
+Prints the mime type of the file given. A full path must be specified. This command is intended to help get the ftype parameter of rules correct by seeing how fapolicyd will classify it. fapolicyd may differ from the \fBfile\fP command.
 .TP
 .B \-l, \-\-list
 Prints a listing of the fapolicyd rules file with a rule number to aid in troubleshooting or understanding of the debug messages.

--- a/doc/fapolicyd.conf.5
+++ b/doc/fapolicyd.conf.5
@@ -16,7 +16,7 @@ This option gives fapolicyd a scheduler boost. The number can be from 0 to 20. T
 
 .TP
 .B q_size
-This option is used to control how big of an internal queue that fapolicyd will use. If requests come in faster than fapolicyd can answer, the queue holds the pending requests. If the do_stat_report is enabled, when fapolicyd shutsdown it will provide some statistics which includes maximum queue depth used. This information can be used to help tune performance. The default value is 1024.
+This option is used to control how big of an internal queue that fapolicyd will use. If requests come in faster than fapolicyd can answer, the queue holds the pending requests. If the do_stat_report is enabled, when fapolicyd shuts down it will provide some statistics which includes maximum queue depth used. This information can be used to help tune performance. The default value is 1024.
 
 .TP
 .B uid
@@ -52,7 +52,7 @@ This is a comma separated list of file systems that should be watched for access
 
 .TP
 .B trust
-This is a comma separated list of trust back-ends. If this is not configured, 'rpmdb,file' is default. Fapolicyd supports \fBfile\fP back-end that reads content of /etc/fapolicyd/fapolicyd.trust and use it as a list of trusted files. The second option is \fBrpmdb\fP backend that generates list of trusted files from rpmdb.
+This is a comma separated list of trust back-ends. If this is not configured, 'rpmdb,file' is default. fapolicyd supports \fBfile\fP back-end that reads content of /etc/fapolicyd/fapolicyd.trust and use it as a list of trusted files. The second option is \fBrpmdb\fP backend that generates list of trusted files from rpmdb.
 
 .TP
 .B integrity

--- a/doc/fapolicyd.rules.5
+++ b/doc/fapolicyd.rules.5
@@ -99,7 +99,7 @@ This option will match against the device that the executable resides on. To use
 
 .TP
 .B pattern
-There are various ways that an attacker may try to execute code that may reveal itself in the pattern of file accesses made during program startup. This rule can take one of several options depending on which access patterns is wished to be blocked. Fapolicyd is able to detect these different access patterns and provide the access decision as soon as it identifies the pattern. The pattern type can be any of:
+There are various ways that an attacker may try to execute code that may reveal itself in the pattern of file accesses made during program startup. This rule can take one of several options depending on which access patterns is wished to be blocked. fapolicyd is able to detect these different access patterns and provide the access decision as soon as it identifies the pattern. The pattern type can be any of:
 
 .RS
 .TP 12
@@ -146,7 +146,7 @@ This option matches against the sha256 hash of the file being accessed. The hash
 .RE
 
 .SH SETS
-Set is a named group of values of the same type. Fapolicyd internally distinguishes between INT and STRING set types. You can define your own set and use it as a value for a specific rule attribute. The definition is in key=value syntax and starts with a set name. The set name has to start with '%' and the rest is alphanumeric or '_'. The value is a comma separated list. The set type is inherited from the first item in the list. If that can be turned into number then whole list is expected to carry numbers. One can use these sets as a value for subject and object attributes. It is also possible to use a plain list as an attribute value without previous definition. The assigned set has to match the attribute type. It is not possible set groups for TRUST and PATTERN attributes.
+Set is a named group of values of the same type. fapolicyd internally distinguishes between INT and STRING set types. You can define your own set and use it as a value for a specific rule attribute. The definition is in key=value syntax and starts with a set name. The set name has to start with '%' and the rest is alphanumeric or '_'. The value is a comma separated list. The set type is inherited from the first item in the list. If that can be turned into number then whole list is expected to carry numbers. One can use these sets as a value for subject and object attributes. It is also possible to use a plain list as an attribute value without previous definition. The assigned set has to match the attribute type. It is not possible set groups for TRUST and PATTERN attributes.
 
 
 .SS SETS EXAMPLES

--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -18,7 +18,7 @@ Requires(preun): systemd-units
 Requires(postun): systemd-units
 
 %description
-Fapolicyd (File Access Policy Daemon) implements application whitelisting
+fapolicyd (File Access Policy Daemon) implements application whitelisting
 to decide file access rights. Applications that are known via a reputation
 source are allowed access while unknown applications are not. The daemon
 makes use of the kernel's fanotify interface to determine file access rights.

--- a/src/cli/fapolicyd-cli.c
+++ b/src/cli/fapolicyd-cli.c
@@ -53,7 +53,7 @@
 #include "paths.h"
 
 static const char *usage =
-"Fapolicyd CLI Tool\n\n"
+"fapolicyd CLI Tool\n\n"
 "--check-config        Check the daemon config for syntax errors\n"
 "--check-path          Check files in $PATH against the trustdb for problems\n"
 "--check-status        Dump the deamon's internal performance statistics\n"
@@ -500,7 +500,7 @@ static int do_update(void)
 		return 1;
 	}
 
-	printf("Fapolicyd was notified\n");
+	printf("fapolicyd was notified\n");
 	return 0;
 }
 


### PR DESCRIPTION
I think "Fapolicyd" is not appropriate and should be renamed in "fapolicyd" (all lowercase).
At least this should be consistent.