### PR TITLE
Unsupported backend is an error

### DIFF
--- a/src/library/backend-manager.c
+++ b/src/library/backend-manager.c
@@ -65,15 +65,15 @@ static int backend_push(const char *name)
 	}
 
 	if (index == -1) {
-		msg(LOG_INFO, "%s backend not supported, skipping!", name);
-		return 0;
+		msg(LOG_ERR, "%s backend not supported, aborting!", name);
+		return 1;
 	} else {
 		backend_entry *tmp = (backend_entry *)
 				malloc(sizeof(backend_entry));
 
 		if (!tmp) {
 			msg(LOG_ERR, "cannot allocate %s backend", name);
-			return 1;
+			return 2;
 		}
 
 		tmp->backend = compiled[index];


### PR DESCRIPTION
- reverts basically 781df888d079746b97bb9c294e91bb93652de2fd and 190a92d75ece5028527902d20ba52095b2b4f0e8

- not an error causes possibility to load a trust from .conf empty when there is no valid backend name which leads to the situation where everything on the system is untrusted