### PR TITLE
Fix broken backwards compatibility backend numbers

### DIFF
--- a/src/library/fapolicyd-backend.h
+++ b/src/library/fapolicyd-backend.h
@@ -28,7 +28,7 @@
 #include "conf.h"
 #include "llist.h"
 
-typedef enum { SRC_UNKNOWN, SRC_RPM, SRC_DEB, SRC_FILE_DB } trust_src_t;
+typedef enum { SRC_UNKNOWN, SRC_RPM, SRC_FILE_DB, SRC_DEB } trust_src_t;
 
 // source, size, sha
 #define DATA_FORMAT "%u %lu %64s"


### PR DESCRIPTION
- when debian backend was merged it casued a change in backend numbering so this commit fixes the numbers as they were before
- this numbers are also in trustdb so it is affected as well