### PR TITLE
Fix doc typo for SIGTERM

### DIFF
--- a/doc/fapolicyd.8
+++ b/doc/fapolicyd.8
@@ -40,7 +40,7 @@ when fapolicyd ends, it dumps a usage report with various statistics that may be
 .SH SIGNALS
 .TP
 .B SIGTERM
-caused fapolicyd to discontinue processing events, write it's performance report, and exit.
+causes fapolicyd to discontinue processing events, write it's performance report, and exit.
 
 .TP
 .B SIGHUP


### PR DESCRIPTION
While reading the man page, I noticed the docs say SIGTERM "caused xyz..." while the other signals "causes xyz...". Quick typo fix for tense.