### PR TITLE
Ensure that `/run/fapolicyd` exists before performing file operations 

### DIFF
--- a/src/library/database.c
+++ b/src/library/database.c
@@ -116,8 +116,15 @@ int preconstruct_fifo(const conf_t *config)
 	int rc;
 	char err_buff[BUFFER_SIZE];
 
-	/* Make sure that there is no such file/fifo */
-	unlink_fifo();
+	/* Ensure that the RUN_DIR exists */
+	if (mkdir(RUN_DIR, 0770) && errno != EEXIST) {
+		msg(LOG_ERR, "Failed to create a directory %s (%s)", RUN_DIR,
+		    strerror_r(errno, err_buff, BUFFER_SIZE));
+		return 1;
+	} else {
+		/* Make sure that there is no such file/fifo */
+		unlink_fifo();
+	}
 
 	rc = mkfifo(fifo_path, 0660);
 
@@ -1468,4 +1475,3 @@ void walk_database_finish(void)
 	abort_transaction(lt_txn);
 	close_db(0);
 }
-

--- a/src/library/paths.h
+++ b/src/library/paths.h
@@ -33,6 +33,7 @@
 #define DB_DIR          "/var/lib/fapolicyd"
 #define DB_NAME         "trust.db"
 #define REPORT          "/var/log/fapolicyd-access.log"
+#define RUN_DIR         "/run/fapolicyd/"
 #define STAT_REPORT     "/run/fapolicyd.state"
 #define fifo_path       "/run/fapolicyd/fapolicyd.fifo"
 #define pidfile         "/run/fapolicyd.pid"

--- a/src/library/paths.h
+++ b/src/library/paths.h
@@ -34,7 +34,7 @@
 #define DB_NAME         "trust.db"
 #define REPORT          "/var/log/fapolicyd-access.log"
 #define RUN_DIR         "/run/fapolicyd/"
-#define STAT_REPORT     "/run/fapolicyd.state"
+#define STAT_REPORT     "/run/fapolicyd/fapolicyd.state"
 #define fifo_path       "/run/fapolicyd/fapolicyd.fifo"
 #define pidfile         "/run/fapolicyd.pid"
 


### PR DESCRIPTION
While attempting to test a freshly built `fapolicyd` on Gentoo as per the [README](https://github.com/linux-application-whitelisting/fapolicyd/#experimenting) - `/usr/sbin/fapolicyd --permissive --debug`, it would consistently fail to start.

Some debugging revealed the following:

```
umask(0117)                             = 022
unlink("/run/fapolicyd/fapolicyd.fifo") = -1 ENOENT (No such file or directory)
mknodat(AT_FDCWD, "/run/fapolicyd/fapolicyd.fifo", S_IFIFO|0660) = -1 ENOENT (No such file or directory)
write(2, "Failed to create a pipe /run/fap"..., 81Failed to create a pipe /run/fapolicyd/fapolicyd.fifo (No such file or directory)) = 81
```

This set of patches:

- has the `preconstruct_fifo` function ensure that `/run/fapolicyd` exists
- moves `fapolicyd.state` to `/run/fapolicyd/`