### PR TITLE
Improve logging: make stderr output more colourful; add timestamps

### DIFF
--- a/src/daemon/fapolicyd.c
+++ b/src/daemon/fapolicyd.c
@@ -41,6 +41,7 @@
 #include <seccomp.h>
 #include <stdatomic.h>
 #include <limits.h>        /* PATH_MAX */
+#include <locale.h>
 #include "notify.h"
 #include "policy.h"
 #include "event.h"
@@ -455,6 +456,8 @@ int main(int argc, const char *argv[])
 	struct sigaction sa;
 	struct rlimit limit;
 
+	char *locale = setlocale(LC_TIME, "");
+
 	if (argc > 1 && strcmp(argv[1], "--help") == 0)
 		usage();
 	set_message_mode(MSG_STDERR, debug_mode);
@@ -691,4 +694,3 @@ int main(int argc, const char *argv[])
 
 	return 0;
 }
-


### PR DESCRIPTION
`stderr` logging got colourful and timestamped:

![image](https://github.com/linux-application-whitelisting/fapolicyd/assets/9733178/e17a1714-d9d9-4156-be7e-8dd5ab1af623)