### PR TITLE
Stop blocking signals in other threads

### DIFF
--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -271,26 +271,6 @@ static void clear_ready(void)
 
 static void *deadmans_switch_thread_main(void *arg)
 {
-	sigset_t sigs;
-
-	/* This is a worker thread. Don't handle signals. */
-	sigemptyset(&sigs);
-	sigaddset(&sigs, SIGTERM);
-	sigaddset(&sigs, SIGHUP);
-	sigaddset(&sigs, SIGUSR1);
-	sigaddset(&sigs, SIGINT);
-	sigaddset(&sigs, SIGSEGV);
-	sigaddset(&sigs, SIGABRT);
-	sigaddset(&sigs, SIGBUS);
-	sigaddset(&sigs, SIGFPE);
-	sigaddset(&sigs, SIGILL);
-	sigaddset(&sigs, SIGSYS);
-	sigaddset(&sigs, SIGTRAP);
-	sigaddset(&sigs, SIGXCPU);
-	sigaddset(&sigs, SIGXFSZ);
-	sigaddset(&sigs, SIGQUIT);
-	pthread_sigmask(SIG_SETMASK, &sigs, NULL);
-
 	do {
 		// Are you alive decision thread?
 		if (alive == 0 && get_ready() && !stop &&
@@ -308,26 +288,6 @@ static void *deadmans_switch_thread_main(void *arg)
 
 static void *decision_thread_main(void *arg)
 {
-	sigset_t sigs;
-
-	/* This is a worker thread. Don't handle signals. */
-	sigemptyset(&sigs);
-	sigaddset(&sigs, SIGTERM);
-	sigaddset(&sigs, SIGHUP);
-	sigaddset(&sigs, SIGUSR1);
-	sigaddset(&sigs, SIGINT);
-	sigaddset(&sigs, SIGSEGV);
-	sigaddset(&sigs, SIGABRT);
-	sigaddset(&sigs, SIGBUS);
-	sigaddset(&sigs, SIGFPE);
-	sigaddset(&sigs, SIGILL);
-	sigaddset(&sigs, SIGSYS);
-	sigaddset(&sigs, SIGTRAP);
-	sigaddset(&sigs, SIGXCPU);
-	sigaddset(&sigs, SIGXFSZ);
-	sigaddset(&sigs, SIGQUIT);
-	pthread_sigmask(SIG_SETMASK, &sigs, NULL);
-
 	while (!stop) {
 		int len;
 		struct fanotify_event_metadata metadata[MAX_EVENTS];

--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -271,6 +271,17 @@ static void clear_ready(void)
 
 static void *deadmans_switch_thread_main(void *arg)
 {
+	sigset_t sigs;
+
+	/* This is a worker thread. Don't handle external signals. */
+	sigemptyset(&sigs);
+	sigaddset(&sigs, SIGTERM);
+	sigaddset(&sigs, SIGHUP);
+	sigaddset(&sigs, SIGUSR1);
+	sigaddset(&sigs, SIGINT);
+	sigaddset(&sigs, SIGQUIT);
+	pthread_sigmask(SIG_SETMASK, &sigs, NULL);
+
 	do {
 		// Are you alive decision thread?
 		if (alive == 0 && get_ready() && !stop &&
@@ -288,6 +299,17 @@ static void *deadmans_switch_thread_main(void *arg)
 
 static void *decision_thread_main(void *arg)
 {
+	sigset_t sigs;
+
+	/* This is a worker thread. Don't handle external signals. */
+	sigemptyset(&sigs);
+	sigaddset(&sigs, SIGTERM);
+	sigaddset(&sigs, SIGHUP);
+	sigaddset(&sigs, SIGUSR1);
+	sigaddset(&sigs, SIGINT);
+	sigaddset(&sigs, SIGQUIT);
+	pthread_sigmask(SIG_SETMASK, &sigs, NULL);
+
 	while (!stop) {
 		int len;
 		struct fanotify_event_metadata metadata[MAX_EVENTS];

--- a/src/library/database.c
+++ b/src/library/database.c
@@ -1246,6 +1246,7 @@ static void do_reload_db(conf_t* config)
 static void *update_thread_main(void *arg)
 {
 	int rc;
+	sigset_t sigs;
 	char buff[BUFFER_SIZE];
 	char err_buff[BUFFER_SIZE];
 	conf_t *config = (conf_t *)arg;
@@ -1255,6 +1256,15 @@ static void *update_thread_main(void *arg)
 #ifdef DEBUG
 	msg(LOG_DEBUG, "Update thread main started");
 #endif
+
+	/* This is a worker thread. Don't handle external signals. */
+	sigemptyset(&sigs);
+	sigaddset(&sigs, SIGTERM);
+	sigaddset(&sigs, SIGHUP);
+	sigaddset(&sigs, SIGUSR1);
+	sigaddset(&sigs, SIGINT);
+	sigaddset(&sigs, SIGQUIT);
+	pthread_sigmask(SIG_SETMASK, &sigs, NULL);
 
 	if (ffd[0].fd == 0) {
 		if (preconstruct_fifo(config))

--- a/src/library/database.c
+++ b/src/library/database.c
@@ -1246,7 +1246,6 @@ static void do_reload_db(conf_t* config)
 static void *update_thread_main(void *arg)
 {
 	int rc;
-	sigset_t sigs;
 	char buff[BUFFER_SIZE];
 	char err_buff[BUFFER_SIZE];
 	conf_t *config = (conf_t *)arg;
@@ -1256,23 +1255,6 @@ static void *update_thread_main(void *arg)
 #ifdef DEBUG
 	msg(LOG_DEBUG, "Update thread main started");
 #endif
-
-	/* This is a worker thread. Don't handle signals. */
-	sigemptyset(&sigs);
-	sigaddset(&sigs, SIGTERM);
-	sigaddset(&sigs, SIGHUP);
-	sigaddset(&sigs, SIGINT);
-	sigaddset(&sigs, SIGSEGV);
-	sigaddset(&sigs, SIGABRT);
-	sigaddset(&sigs, SIGBUS);
-	sigaddset(&sigs, SIGFPE);
-	sigaddset(&sigs, SIGILL);
-	sigaddset(&sigs, SIGSYS);
-	sigaddset(&sigs, SIGTRAP);
-	sigaddset(&sigs, SIGXCPU);
-	sigaddset(&sigs, SIGXFSZ);
-	sigaddset(&sigs, SIGQUIT);
-	pthread_sigmask(SIG_SETMASK, &sigs, NULL);
 
 	if (ffd[0].fd == 0) {
 		if (preconstruct_fifo(config))


### PR DESCRIPTION
This is a continuation of #273 

Blocking signals in all other threads but main thread doesn't work, because it leads to crashing then having the kernel coredump handler be called from crashing threads, without calling the main thread signal handler.
This is especially true with signals being raised internally, such as SIGSEGV or SIGBUS.

The solution consists in not blocking signals anymore, but raising the signal again for main thread in case the signal handler is running from another thread.

---

### Without the patch (reproducer)

Tested on RHEL9 with 1.3.2-100.el9
The hang can be reproduced through injecting SIGBUS using systemtap, as if the RPMDB was crashing (this is based on real customer scenario).

1. Start stap injector

   ~~~
   # yum -y install systemtap
   # stap-prep
   # stap -v -g -d /usr/sbin/fapolicyd --ldd -e 'probe process("/usr/sbin/fapolicyd").function("rpm_load_list@library/rpm-backend.c") { if (tid() == pid()) next; printf("%ld (%s): sending SIGBUS\n", tid(), execname()); raise(%{SIGBUS%}) }'
   [...]
   ~~~

2. Reload RPMDB

   ~~~
   # fapolicyd-cli -u
   Fapolicyd was notified
   --> hang
   ~~~

3. Confirm stap injected SIGBUS

   ~~~
   1746 (fapolicyd): sending SIGBUS
   ~~~

4. Collect blocked tasks from hypervisor (QEMU/KVM)

   ~~~
   $ virsh send-key fapolicy9 KEY_LEFTALT KEY_SYSRQ KEY_W
   ~~~

   Console shows blocked tasks: [fapolicy9_unpatched.log](https://github.com/linux-application-whitelisting/fapolicyd/files/13560126/fapolicy9_unpatched.log)
   We can see main thread (PID 1745) and other threads hanging on exit, crashing thread (PID 1746) calling coredump generator (do_coredump).
   We can also see kernel coredump generator (kworker/u4, PID 1761) hanging waiting on fanotify event handling.

---

### With the patch

1. fapolicyd crashes and restarts
2. no hang happens
3. Killing another thread than main thread externally (using `kill -BUS <PID>`) doesn't hang either