### PR TITLE
Add --reload-rules doc

### DIFF
--- a/doc/fapolicyd-cli.8
+++ b/doc/fapolicyd-cli.8
@@ -56,6 +56,9 @@ Prints a listing of the fapolicyd rules file with a rule number to aid in troubl
 .TP
 .B \-u, \-\-update
 Notifies fapolicyd to perform an update of the trust database.
+.TP
+.B \-r, \-\-reload-rules
+Notifies fapolicyd to perform a reload of the rules.
 .SH "SEE ALSO"
 .BR fapolicyd (8),
 .BR fapolicyd.rules (5),

--- a/init/fapolicyd.bash_completion
+++ b/init/fapolicyd.bash_completion
@@ -8,7 +8,7 @@ _fapolicydcli()
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 	opts="--check-config --check-path --check-status --check-trustdb \
                 --check-watch_fs --delete-db --dump-db \
-                --file --ftype --help --list --update"
+                --file --ftype --help --list --update --reload-rules"
 
 	case $prev in
 		--ftype)


### PR DESCRIPTION
Missing doc on the --reload-rules option

- add to man page
- add to bash completion