### PR TITLE
Configurable metric reporting interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ had a common denominator. Some primes you might consider for cache size are:
 1021, 1549, 2039, 4099, 6143, 8191, 10243, 12281, 16381, 20483, 24571,
 28669, 32687, 40961, 49157, 57347, 65353, etc.
 
+This report can be scheduled to be written periodically by setting the
+configuration option `report_interval`. This option is set to `0` by default
+which disables the reporting interval. A positive value for this option
+specifies the number of seconds to wait between reports.
+
 Also, it should be mentioned that the more rules in the policy, the more
 rules it will have to iterate over to make a decision. As for the system
 performance impact, this is very workload dependent. For a typical desktop

--- a/doc/fapolicyd-cli.8
+++ b/doc/fapolicyd-cli.8
@@ -17,7 +17,7 @@ Opens fapolicyd.conf and parses it to see if there are any syntax errors in the 
 Check the PATH environmental variable against the trustdb to look for file not in the trustdb which could cause problems at run time.
 .TP
 .B \-\-check-status
-Dump the daemon's internal performance statistics.
+Dump the daemon's internal performance statistics. See also the fapolicyd.conf option \fBreport_interval\fP.
 .TP
 .B \-\-check-trustdb
 Check the trustdb against the files on disk to look for mismatches that will cause problems at run time.

--- a/doc/fapolicyd.conf.5
+++ b/doc/fapolicyd.conf.5
@@ -91,6 +91,10 @@ The option set to 1 forces the daemon to work only with SHA256 hashes. This is u
 .B allow_filesystem_mark
 When this option is set to 1, it allows fapolicyd to monitor file access events on the underlying file system when they are bind mounted or are overlayed (e.g. the overlayfs). Normally they block fapolicyd from seeing events on the underlying file systems. This may or may not be desirable. For example, you might start seeing containers accessing things outside of the container but there is no source of trust for the container. In that case you probably do not want to see access from the container. Or maybe you do not use containers but want to control anything run by systemd-run when dynamic users are allowed. In that case you probably want to turn it on. Not all kernel's support this option. Therefore the default value is 0.
 
+.TP
+.B report_interval
+This option specifies a reporting interval, measured in seconds, which fapolicyd uses to schedule a recurring dump of internal performance statistics to the \fBfapolicyd.state\fP file. The default value of 0 disables interval reporting.
+
 .SH "SEE ALSO"
 .BR fapolicyd (8),
 .BR fapolicyd-cli (8)

--- a/init/fapolicyd.conf
+++ b/init/fapolicyd.conf
@@ -19,3 +19,4 @@ integrity = none
 syslog_format = rule,dec,perm,auid,pid,exe,:,path,ftype,trust
 rpm_sha256_only = 0
 allow_filesystem_mark = 0
+report_interval = 0

--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -33,6 +33,7 @@
 #include <pthread.h>
 #include <signal.h>
 #include <sys/syscall.h>
+#include <sys/timerfd.h>
 #include <stdbool.h>
 #include <stdatomic.h>
 #include "policy.h"
@@ -57,11 +58,14 @@ static pthread_t deadmans_switch_thread;
 static pthread_mutexattr_t decision_lock_attr;
 static pthread_mutex_t decision_lock;
 static pthread_cond_t do_decision;
+static pthread_condattr_t rpt_timer_attr;
 static volatile atomic_bool events_ready;
 static volatile atomic_int alive = 1;
 static int fd = -1;
+static int rpt_timer_fd = -1;
 static uint64_t mask;
 static unsigned int mark_flag;
+static unsigned int rpt_interval;
 
 // External functions
 void do_stat_report(FILE *f, int shutdown);
@@ -114,7 +118,10 @@ int init_fanotify(const conf_t *conf, mlist *m)
 	pthread_mutexattr_settype(&decision_lock_attr,
 						PTHREAD_MUTEX_ERRORCHECK);
 	pthread_mutex_init(&decision_lock, &decision_lock_attr);
-	pthread_cond_init(&do_decision, NULL);
+    pthread_condattr_init(&rpt_timer_attr);
+    pthread_condattr_setclock(&rpt_timer_attr, CLOCK_MONOTONIC);
+	pthread_cond_init(&do_decision, &rpt_timer_attr);
+	rpt_interval = conf->report_interval;
 	events_ready = false;
 	pthread_create(&decision_thread, NULL, decision_thread_main, NULL);
 	pthread_create(&deadmans_switch_thread, NULL,
@@ -239,6 +246,7 @@ void shutdown_fanotify(mlist *m)
 
 	// Clean up
 	q_close(q);
+    close(rpt_timer_fd);
 
 	// Report results
 	msg(LOG_DEBUG, "Allowed accesses: %lu", getAllowed());
@@ -298,6 +306,42 @@ static void *deadmans_switch_thread_main(void *arg)
 	return NULL;
 }
 
+// disable interval reports, used on unrecoverable errors
+static void rpt_disable(const char *why)
+{
+    rpt_interval = 0;
+    close(rpt_timer_fd);
+    msg(LOG_WARNING, "interval reports disabled; %s", why);
+}
+
+// initialize interval reporting
+static void rpt_init(struct timespec *t)
+{
+    rpt_timer_fd = timerfd_create(CLOCK_REALTIME, TFD_NONBLOCK);
+    if (rpt_timer_fd == -1) {
+        rpt_disable("timer create failure");
+    } else {
+        t->tv_nsec = t->tv_sec = 0;
+        struct itimerspec rpt_deadline = { {rpt_interval, 0}, {rpt_interval, 0} };
+        if (timerfd_settime(rpt_timer_fd, TFD_TIMER_ABSTIME, &rpt_deadline, NULL) == -1) {
+            // settime errors are unrecoverable
+            rpt_disable(strerror(errno));
+        } else {
+            msg(LOG_INFO, "interval reports configured; %us", rpt_interval);
+        }
+    }
+}
+
+// write a stat report to file at the standard location
+static void rpt_write(void)
+{
+    FILE *f = fopen(STAT_REPORT, "w");
+    if (f) {
+        do_stat_report(f, 0);
+        fclose(f);
+    }
+}
+
 static void *decision_thread_main(void *arg)
 {
 	sigset_t sigs;
@@ -311,26 +355,71 @@ static void *decision_thread_main(void *arg)
 	sigaddset(&sigs, SIGQUIT);
 	pthread_sigmask(SIG_SETMASK, &sigs, NULL);
 
+    // interval reporting state
+    int rpt_is_stale = 0;
+    struct timespec rpt_timeout;
+
+    // if an interval was configured, reports are enabled
+    if (rpt_interval) {
+        rpt_init(&rpt_timeout);
+    }
+
+    // start with a fresh report
+    run_stats = 1;
+
 	while (!stop) {
 		int len;
 		struct fanotify_event_metadata metadata[MAX_EVENTS];
 
 		pthread_mutex_lock(&decision_lock);
 		while (get_ready() == 0) {
-			pthread_cond_wait(&do_decision, &decision_lock);
-			if (stop)
-				return NULL; // decision_lock is released
+            // if an interval has been configured
+            if (rpt_interval) {
+                // check for timer expirations
+                uint64_t expired = 0;
+                if (read(rpt_timer_fd, &expired, sizeof(uint64_t)) == -1) {
+                    // EAGAIN expected with nonblocking timer
+                    // any other error is unrecoverable
+                    if (errno != EAGAIN) {
+                        rpt_disable(strerror(errno));
+                        continue;
+                    }
+                }
+                // if the timer expired or stats were explicitly requested
+                if (expired || run_stats) {
+                    // write a new report only when one of
+                    // 1. new events observed since last report
+                    // 2. explicitly requested with run_stats
+                    if (rpt_is_stale || run_stats) {
+                        rpt_write();
+                        run_stats = 0;
+                        rpt_is_stale = 0;
+                    }
+                    // adjust the pthread timeout to a full interval from now
+                    if (clock_gettime(CLOCK_MONOTONIC, &rpt_timeout)) {
+                        // gettime errors are unrecoverable
+                        rpt_disable("clock failure");
+                        continue;
+                    }
+                    rpt_timeout.tv_sec += rpt_interval;
+                }
+                // await a fan event, timing out at the next report interval
+                pthread_cond_timedwait(&do_decision, &decision_lock, &rpt_timeout);
+            } else {
+                if (run_stats) {
+                    rpt_write();
+                    run_stats = 0;
+                }
+                // no interval reports, so await a fan event indefinitely
+                pthread_cond_wait(&do_decision, &decision_lock);
+            }
 
-			if (run_stats) {
-				FILE *f = fopen(STAT_REPORT, "w");
-				if (f) {
-					do_stat_report(f, 0);
-					fclose(f);
-				}
-				run_stats = false;
+			if (stop) {
+				return NULL;
 			}
 		}
 		alive = 1;
+        rpt_is_stale = 1;
 
 		// Grab up to MAX_EVENTS events while locked
 		unsigned i = 0;

--- a/src/library/conf.h
+++ b/src/library/conf.h
@@ -46,6 +46,7 @@ typedef struct conf
 	const char *syslog_format;
 	unsigned int rpm_sha256_only;
 	unsigned int allow_filesystem_mark;
+    unsigned int report_interval;
 } conf_t;
 
 #endif

--- a/src/library/daemon-config.c
+++ b/src/library/daemon-config.c
@@ -94,6 +94,8 @@ static int rpm_sha256_only_parser(const struct nv_pair *nv, int line,
 		conf_t *config);
 static int fs_mark_parser(const struct nv_pair *nv, int line,
 		conf_t *config);
+static int report_interval_parser(const struct nv_pair *nv, int line,
+        conf_t *config);
 
 static const struct kw_pair keywords[] =
 {
@@ -113,6 +115,7 @@ static const struct kw_pair keywords[] =
   {"syslog_format",	syslog_format_parser },
   {"rpm_sha256_only", rpm_sha256_only_parser},
   {"allow_filesystem_mark",	fs_mark_parser },
+  {"report_interval",	report_interval_parser },
   { NULL,		NULL }
 };
 
@@ -142,6 +145,7 @@ static void clear_daemon_config(conf_t *config)
 		strdup("rule,dec,perm,auid,pid,exe,:,path,ftype");
 	config->rpm_sha256_only = 0;
 	config->allow_filesystem_mark = 0;
+    config->report_interval = 0;
 }
 
 int load_daemon_config(conf_t *config)
@@ -527,6 +531,12 @@ static int watch_fs_parser(const struct nv_pair *nv, int line,
 		return 0;
 	msg(LOG_ERR, "Could not store value line %d", line);
 	return 1;
+}
+
+static int report_interval_parser(const struct nv_pair *nv, int line,
+        conf_t *config)
+{
+    return unsigned_int_parser(&(config->report_interval), nv->value, line);
 }
 
 


### PR DESCRIPTION
Provides recurring metric reports at a specified interval.

Uses a nonblocking timerfd alongside pthread_cond_timedwait to create timed reporting intervals. The interval is configured through the `report_interval` key in fapolicyd.conf. This value represents the length of interval in seconds between reports. If set to `0` reporting intervals are disabled, this is the default.

Reports are written to the `fapolicyd.state` file. The output format and contents of this file are unchanged by this PR. This is the same file that was written at shutdown and upon receiving `SIGUSR1`. The signal handling function remains unchanged.

Error handling is based around disabling interval reporting to preserve the decision thread. When an unrecoverable reporting error occurs the interval reports are disabled and the decision thread will use the non-interval report handler for the remainder of it's execution.  

The structuring of the reporting loop gives priority to the fan handling loop. When a reporting interval expires, the fan handler runs prior to writing the report to prioritize the fan handling and also to ensure the cache stats are as recent as possible. Also the reporting loop is only entered when no fan events have been recorded.

This PR also restructure the initialization of the decision thread and reporting loop to ensure a fresh `fapolicyd.state` file when fapolicyd starts. The previous behavior was that the file from the last shutdown was still present until either a `SIGUSR1` or shutdown.
