### PR TITLE
ID begins with a digit or minus sign

### DIFF
--- a/src/library/rules.c
+++ b/src/library/rules.c
@@ -348,7 +348,8 @@ static int assign_subject(lnode *n, int type, const char *ptr2, int lineno)
 
 		ptr = strtok_r(tmp, ",", &saved);
 		while (ptr) {
-			if (isdigit(*ptr)) {
+            // starts with a digit or minus sign
+			if (isdigit(*ptr) || *ptr == '-') {
 				errno = 0;
 				long val = strtol(ptr, NULL, 10);
 				if (errno) {


### PR DESCRIPTION
Rules with auid=-1 (user not defined) can be useful to avoid blocking calls on behalf of the system.