### PR TITLE
Allow override of mounts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ information for the file being accessed, you can add it. You can also enable
 this information to go to syslog by changing the rules to not say audit, but
 instead have syslog or log appended to the allow or deny decision.
 
+OVERRIDE MOUNTS WHILE DEBUGGING
+-------------------------------
+When debugging you can specify an alternative mounts file to the deamon
+to watch for event notifications. This allows for finer level of control
+than is achievable by filtering by filesystem type.
+
+The alternative mounts file will expect the same format as `/proc/mounts`,
+which allows us to select entries from `/proc/mounts` into a new file which
+fapolicyd will use as the mount source.
+
+For example, use grep to select a single mount point:
+```
+mount -t tmpfs tmpfs /tmp/my-test-dir 
+grep my-test-dir /proc/mounts > /tmp/my-test-mounts
+fapolicyd --debug --mounts=/tmp/my-test-mounts
+```
+
+Here we mount a tmpfs for testing in `/tmp`, and grep it from `/proc/mounts`
+into the overriding mounts file, then run fapolicyd in debug mode while
+specifying the override file. The result is fapolicyd only receives events
+that occur in `/tmp/my-test-dir`.
+
 WRITING RULES
 -------------
 The authoritative source is the fapolicyd.rules man page.

--- a/doc/fapolicyd.8
+++ b/doc/fapolicyd.8
@@ -35,6 +35,9 @@ leave the daemon in the foreground for debugging. Event information is written t
 .B \-\-permissive
 the daemon will allow file access regardless of the policy decision. This is useful for debugging rules before making them permanent.
 .TP
+.B \-\-mounts=PATH
+only in debug mode will the daemon use this flag to override the source of fanotify mounts with the contents of the file at the specified path. This file must be the same format as /proc/mounts, which allows one to head, tail, or grep a sublist from /proc/mounts into a file passed with this arg.
+.TP
 .B \-\-no-details
 when fapolicyd ends, it dumps a usage report with various statistics that may be useful for tuning performance. It can also detail which processes it knew about and files being accessed by them. This can be useful for forensics investigations. In some settings, this may not be desirable as the file names may be sensitive. Using this option removes process and file names leaving only the statistics. The default without giving this option is to generate a full report.
 .SH SIGNALS


### PR DESCRIPTION
When in debug mode the default /proc/mounts source can be overridden to customize the source of fanotify events. This allows for finer level of control than is achievable with filesystem type filtering.

The intent here is to restrict events to specific locations when testing to make interpreting the event stream easier.

The alternative mounts file will expect the same format as /proc/mounts, allowing us to head, tail, or grep sublists from /proc/mounts into a new file that fapolicyd will use as the mount source.


An example of restricting fapolicyd to only listen in a test directory
```plain
$ mount -t tmpfs tmpfs /tmp/test-dir
$ grep test-dir /proc/mounts > /tmp/my-test-mounts
$ fapolicyd --debug --mounts=/tmp/my-test-mounts
```

```plain
$ cat /tmp/my-test-mounts
tmpfs /tmp/test-dir tmpfs rw,relatime,inode64 0 0
```

Only enabling this for debug mode, as it's not intended to be a feature used outside of debugging and testing a system.