### PR TITLE
Path trimmer option

### DIFF
--- a/doc/fapolicyd.conf.5
+++ b/doc/fapolicyd.conf.5
@@ -95,6 +95,10 @@ When this option is set to 1, it allows fapolicyd to monitor file access events 
 .B report_interval
 This option specifies a reporting interval, measured in seconds, which fapolicyd uses to schedule a recurring dump of internal performance statistics to the \fBfapolicyd.state\fP file. The default value of 0 disables interval reporting.
 
+.TP
+.B path_trimmer
+This option specifies the path transformation before adding to the database and before file checking. For example, if all users on the host use certain software, e.g. flatpak, from their home directories, you might want to exclude /home/<user> or may be /mnt/nfs/home from the file path checking. POSIX-compatible regex mode is used, the resulting value is the last capturing regex group. For example, expression /(home|mnt/nfs/home)/[^/]+/(.*) returns the same relative paths to applications for all users. Note that there is no need to enclose the expression in quotation marks, a single $ sign will be interpreted as an match nothing expression. The default value is the match nothing.
+
 .SH "SEE ALSO"
 .BR fapolicyd (8),
 .BR fapolicyd-cli (8)

--- a/init/fapolicyd.conf
+++ b/init/fapolicyd.conf
@@ -20,3 +20,4 @@ syslog_format = rule,dec,perm,auid,pid,exe,:,path,ftype,trust
 rpm_sha256_only = 0
 allow_filesystem_mark = 0
 report_interval = 0
+path_trimmer = $

--- a/src/cli/fapolicyd-cli.c
+++ b/src/cli/fapolicyd-cli.c
@@ -51,6 +51,11 @@
 #include "llist.h"
 #include "fd-fgets.h"
 #include "paths.h"
+#include "regex.h"
+
+// Global program variables
+char *path_trimmer = NULL;
+regex_t path_trimmer_compiled;
 
 static const char *usage =
 "Fapolicyd CLI Tool\n\n"

--- a/src/library/conf.h
+++ b/src/library/conf.h
@@ -47,6 +47,7 @@ typedef struct conf
 	unsigned int rpm_sha256_only;
 	unsigned int allow_filesystem_mark;
     unsigned int report_interval;
+	const char *path_trimmer;
 } conf_t;
 
 #endif

--- a/src/library/daemon-config.c
+++ b/src/library/daemon-config.c
@@ -96,6 +96,8 @@ static int fs_mark_parser(const struct nv_pair *nv, int line,
 		conf_t *config);
 static int report_interval_parser(const struct nv_pair *nv, int line,
         conf_t *config);
+static int path_trimmer_parser(const struct nv_pair *nv, int line,
+        conf_t *config);
 
 static const struct kw_pair keywords[] =
 {
@@ -116,6 +118,7 @@ static const struct kw_pair keywords[] =
   {"rpm_sha256_only", rpm_sha256_only_parser},
   {"allow_filesystem_mark",	fs_mark_parser },
   {"report_interval",	report_interval_parser },
+  {"path_trimmer",     path_trimmer_parser },
   { NULL,		NULL }
 };
 
@@ -146,6 +149,7 @@ static void clear_daemon_config(conf_t *config)
 	config->rpm_sha256_only = 0;
 	config->allow_filesystem_mark = 0;
     config->report_interval = 0;
+	config->path_trimmer = strdup("");
 }
 
 int load_daemon_config(conf_t *config)
@@ -351,6 +355,7 @@ void free_daemon_config(conf_t *config)
 	free((void*)config->watch_fs);
 	free((void*)config->trust);
 	free((void*)config->syslog_format);
+	free((void*)config->path_trimmer);
 }
 
 static int unsigned_int_parser(unsigned *i, const char *str, int line)
@@ -644,4 +649,15 @@ static int fs_mark_parser(const struct nv_pair *nv, int line,
 #endif
 
 	return rc;
+}
+
+static int path_trimmer_parser(const struct nv_pair *nv, int line,
+        conf_t *config)
+{
+	free((void *)config->path_trimmer);
+	config->path_trimmer = strdup(nv->value);
+	if (config->path_trimmer)
+		return 0;
+	msg(LOG_ERR, "Could not store value line %d", line);
+return 1;
 }

--- a/src/library/file.c
+++ b/src/library/file.c
@@ -896,7 +896,7 @@ const char *get_last_regex_group(const char *path)
         for (size_t i = 0; i < max_groups; i++)
 			if ((long unsigned int) group_array[i].rm_so == (size_t)-1) {
 				memcpy((void *) path, (void *) path + group_array[i-1].rm_so,
-					strlen(path + group_array[i-1].rm_so));
+					strlen(path + group_array[i-1].rm_so) + 1);
 				return path;
 			}
     return path;

--- a/src/library/file.h
+++ b/src/library/file.h
@@ -61,5 +61,6 @@ char *bytes2hex(char *final, const unsigned char *buf, unsigned int size)
 char *get_hash_from_fd2(int fd, size_t size, int is_sha) __attr_dealloc_free;
 int get_ima_hash(int fd, char *sha);
 uint32_t gather_elf(int fd, off_t size);
+const char *get_last_regex_group(const char *path);
 
 #endif


### PR DESCRIPTION
Path_trimmer option specifies the path transformation before adding to the database and before file checking. For example, if all users on the host use certain software, e.g. flatpak, from their home directories, you might want to exclude /home/<user> or may be /mnt/nfs/home from the file path checking. POSIX-compatible regex mode is used, the resulting value is the last capturing regex group. For example, expression /(home|mnt/nfs/home)/[^/]+/(.*) returns the same relative paths to applications for all users. Note that there is no need to enclose the expression in quotation marks, a single $ sign will be interpreted as an match nothing expression. The default value is the match nothing.

add dir:
```
[root@localhost ~]# /usr/local/sbin/fapolicyd-cli --file add /home/jdoe --trust-file home.trust
```

db check:
```
[root@localhost ~]# /usr/local/sbin/fapolicyd-cli -D | grep kubectl
filedb Downloads/kubectl 51454104 7c3807c0f5c1b30110a2ff1e55da1d112a6d0096201f1beb81b269f582b5d1c5
```

debug:
```
05/14/2024 10:48:55 [ DEBUG ]: rule=9 dec=allow perm=execute auid=1001 pid=19161 exe=/usr/bin/bash : path=Downloads/kubectl ftype=application/x-executable trust=1
05/14/2024 10:48:55 [ DEBUG ]: rule=14 dec=allow perm=open auid=1001 pid=19161 exe=/usr/bin/bash : path=Downloads/kubectl ftype=application/x-executable trust=1
```
