### PR TITLE
Increase buffer size for reading process groups

### DIFF
--- a/src/library/process.c
+++ b/src/library/process.c
@@ -38,6 +38,8 @@
 #include "process.h"
 #include "file.h"
 
+#define BUF_SIZE 8192 // Buffer for reading pid status, mainly for group list
+
 #define BUFSZ 12  // Largest unsigned int is 10 characters long
 /*
  * This is an optimized integer to string conversion. It only
@@ -339,8 +341,7 @@ uid_t get_program_uid_from_pid(pid_t pid)
 
 attr_sets_entry_t *get_gid_set_from_pid(pid_t pid)
 {
-	const int buf_size = 8192;
-    char buf[buf_size];
+    char buf[BUF_SIZE];
 	int gid = -1;
 	FILE *f;
 	attr_sets_entry_t *set = init_standalone_set(INT);
@@ -350,7 +351,7 @@ attr_sets_entry_t *get_gid_set_from_pid(pid_t pid)
 		f = fopen(path, "rt");
 		if (f) {
 			__fsetlocking(f, FSETLOCKING_BYCALLER);
-			while (fgets(buf, buf_size, f)) {
+			while (fgets(buf, BUF_SIZE, f)) {
 				if (memcmp(buf, "Gid:", 4) == 0) {
 					sscanf(buf, "Gid: %d ", &gid);
 					append_int_attr_set(set, gid);
@@ -360,7 +361,7 @@ attr_sets_entry_t *get_gid_set_from_pid(pid_t pid)
 
 			char *data;
 			int offset;
-			while (fgets(buf, buf_size, f)) {
+			while (fgets(buf, BUF_SIZE, f)) {
 				if (memcmp(buf, "Groups:", 7) == 0) {
 					data = buf + 7;
 					while (sscanf(data," %d%n", &gid,


### PR DESCRIPTION
Increase buffer size for reading process groups from /proc/pid/status. In a corporate environment, the number of groups can be quite large. Let's assume that 8192 will allow us to read 512 groups.