### PR TITLE
Add Microsoft Windows PE MIME magic definition

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -124,6 +124,7 @@ mkdir --mode=0755 -p /run/fapolicyd/
 cd init
 cp fapolicyd.bash_completion /etc/bash_completion.d/
 cp fapolicyd.conf /etc/fapolicyd/
+cp fapolicyd-magic /usr/share/fapolicyd/
 cp fapolicyd-magic.mgc /usr/share/fapolicyd/
 cp fapolicyd.service /usr/lib/systemd/system/
 cp fapolicyd-tmpfiles.conf /usr/lib/tmpfiles.d/fapolicyd.conf

--- a/doc/fapolicyd.rules.5
+++ b/doc/fapolicyd.rules.5
@@ -87,7 +87,7 @@ in favor of using obj_trust with execute permission when writing rules.
 .RE
 .TP
 .B ftype
-This option takes the mime type of a file as an argument. If you wish to check the mime type of a file while writing rules, run the following command:
+This option takes the mime type of a file as an argument. Mime is determined based on magic patterns files. Fapolicyd uses two precompiled magic files /usr/share/fapolicyd/fapolicyd-magic.mgc and /usr/share/misc/magic.mgc. To compile a magic file run the command \fBfile -C -m <magic file>\fP. If you wish to check the mime type of a file while writing rules, run the following command:
 
 .nf
 .B fapolicyd-cli \-\-ftype /path-to-file
@@ -169,7 +169,7 @@ will run and compile all these component files into one master file, compiled.ru
 .B fagenrules
 man page for more information.
 
-When you are writing a rule for the execute permission, remember that the file to be executed is an 
+When you are writing a rule for the execute permission, remember that the file to be executed is an
 .B object.
 For example, you type ssh into the shell. The shell calls execve on /usr/bin/ssh. At that instant in time, ssh is the object that bash is working on. However, if you are blocking execution
 .I from

--- a/init/fapolicyd-magic
+++ b/init/fapolicyd-magic
@@ -95,3 +95,6 @@
 
 0	string/wt	#!\ /usr/sbin/nft	Netfilter tables script text executable
 !:mime	text/x-nftables
+
+0	belong		0x4d5a9000	Portable executable
+!:mime application/vnd.microsoft.portable-executable

--- a/rules.d/78-known-wine.rules
+++ b/rules.d/78-known-wine.rules
@@ -1,0 +1,4 @@
+# Only allow system wine files
+
+allow perm=any all : ftype=application/vnd.microsoft.portable-executable trust=1
+deny_audit perm=any all : ftype=application/vnd.microsoft.portable-executable


### PR DESCRIPTION
Required to establish trust for executing files from Windows in the Wine environment.