### PR TITLE
Allow rules to express paths using globbing (fnmatch)

### DIFF
--- a/doc/fapolicyd.rules.5
+++ b/doc/fapolicyd.rules.5
@@ -127,7 +127,7 @@ The object is the file that the subject is interacting with. The fields in the r
 This matches against any obbject. When used, this must be the only object in the rule.
 .TP
 .B path
-This is the full path to the file that will be accessed. Globbing is not supported. You may also use the special keyword \fBuntrusted\fP to match on the object not being listed in the rpm database.
+This is the full path to the file that will be accessed. You may also use the special keyword \fBuntrusted\fP to match on the object not being listed in the rpm database. You can use wildcards for untrusted files e.g. /media/*/smb/scripts/*, however this may result in poor performance and negative security implications.
 .TP
 .B dir
 If you wish to match on access to any file in a directory, then use this by giving the full path to the directory. Its recommended to end with the / to ensure it matches a directory. There are 3 keywords that \fIdir\fP supports: \fBexecdirs\fP, \fBsystemdirs\fP, \fBuntrusted\fP. See the \fBdir\fP option under Subject for an explanation of these keywords.
@@ -169,7 +169,7 @@ will run and compile all these component files into one master file, compiled.ru
 .B fagenrules
 man page for more information.
 
-When you are writing a rule for the execute permission, remember that the file to be executed is an 
+When you are writing a rule for the execute permission, remember that the file to be executed is an
 .B object.
 For example, you type ssh into the shell. The shell calls execve on /usr/bin/ssh. At that instant in time, ssh is the object that bash is working on. However, if you are blocking execution
 .I from

--- a/src/library/file.c
+++ b/src/library/file.c
@@ -49,8 +49,8 @@
 // Local defines
 #define IMA_XATTR_DIGEST_NG 0x04	// security/integrity/integrity.h
 
-// Extern variables
-extern list_t wildcards;
+// Global variables
+list_t wildcards;
 
 // Local variables
 static struct udev *udev;

--- a/src/library/policy.c
+++ b/src/library/policy.c
@@ -330,6 +330,9 @@ void destroy_rules(void)
 
 	rules_clear(&rules);
 
+	// Remove wildcards as well
+	list_empty(&wildcards);
+
 	while (i < num_fields) {
 		free((void *)fields[i].name);
 		i++;

--- a/src/library/policy.c
+++ b/src/library/policy.c
@@ -56,7 +56,7 @@ static unsigned long allowed = 0, denied = 0;
 static nvlist_t fields[MAX_SYSLOG_FIELDS];
 static unsigned int num_fields;
 
-// List of path wildcards
+// List of wildcards
 list_t wildcards;
 
 extern volatile atomic_bool stop;
@@ -264,7 +264,7 @@ static int _load_rules(const conf_t *_config, FILE *f)
 			*ptr = 0;
 		msg(LOG_DEBUG, "%s", line);
 
-		// Get wildcards from the rule and add to the list
+		// Get wildcards by keyword from the rule and add to the list
 		char wc_key[16] = "path=";
 		char *wc_data = strstr(line, wc_key);
 		if (wc_data) {

--- a/src/library/policy.c
+++ b/src/library/policy.c
@@ -251,6 +251,7 @@ static int _load_rules(const conf_t *_config, FILE *f)
 	int rc, lineno = 1;
 	char *line = NULL;
 	size_t len = 0;
+	list_init(&wildcards);
 
 	if (rules_create(&rules))
 		return 1;

--- a/src/library/policy.c
+++ b/src/library/policy.c
@@ -76,7 +76,6 @@ static const nv_t table[] = {
 extern unsigned int debug_mode;
 extern unsigned int permissive;
 
-// List of wildcards
 extern list_t wildcards;
 
 #define MAX_DECISIONS (sizeof(table)/sizeof(table[0]))

--- a/src/library/policy.c
+++ b/src/library/policy.c
@@ -56,9 +56,6 @@ static unsigned long allowed = 0, denied = 0;
 static nvlist_t fields[MAX_SYSLOG_FIELDS];
 static unsigned int num_fields;
 
-// List of wildcards
-list_t wildcards;
-
 extern volatile atomic_bool stop;
 volatile atomic_bool reload_rules = false;
 
@@ -78,6 +75,9 @@ static const nv_t table[] = {
 
 extern unsigned int debug_mode;
 extern unsigned int permissive;
+
+// List of wildcards
+extern list_t wildcards;
 
 #define MAX_DECISIONS (sizeof(table)/sizeof(table[0]))
 


### PR DESCRIPTION
You can use wildcards for untrusted files e.g. /media/*/smb/scripts/*, however this may result in poor performance and negative security implications.