### PR TITLE
Uniform separators in state log

### DIFF
--- a/src/library/queue.c
+++ b/src/library/queue.c
@@ -100,7 +100,7 @@ void q_close(struct queue *q)
 
 void q_report(FILE *f)
 {
-	fprintf(f, "Inter-thread max queue depth %u\n", max_depth);
+	fprintf(f, "Inter-thread max queue depth: %u\n", max_depth);
 }
 
 /* add DATA to Q */


### PR DESCRIPTION
This adds a colon after the 'inter-thread max queue depth' entry in the state log.

Having uniform entries makes parsing easier, and all the other entries have a colon after the key.