### PR TITLE
Revert change to report interval logic

### DIFF
--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -414,14 +414,17 @@ static void *decision_thread_main(void *arg)
 				pthread_cond_timedwait(&do_decision,
 						       &decision_lock,
 						       &rpt_timeout);
-			} else if (run_stats) {
-				rpt_write();
-				run_stats = 0;
+			} else {
+				if (run_stats) {
+					rpt_write();
+					run_stats = 0;
+				}
+				if (stop)
+					break;
+
+				// no interval reports, await a fan event indefinitely
+				pthread_cond_wait(&do_decision, &decision_lock);
 			}
-			// no interval reports, await a fan event indefinitely
-			if (stop)
-				break;
-			pthread_cond_wait(&do_decision, &decision_lock);
 		}
 
 		if (stop) {


### PR DESCRIPTION
Undo a change that came along with code formatting in 75acb36.

There was an `else` block changed to an `else if` at line 418 which caused the `pthread_cond_wait` call to fall outside of the else block.

Closes #324 