### PR TITLE
Fix rpmdb locking issues by loading via separate process

### DIFF
--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -268,6 +268,7 @@ fi
 %attr(644,root,root) %{_tmpfilesdir}/%{name}.conf
 %attr(755,root,root) %{_sbindir}/%{name}
 %attr(755,root,root) %{_sbindir}/%{name}-cli
+%attr(755,root,root) %{_sbindir}/%{name}-rpm-loader
 %attr(755,root,root) %{_sbindir}/fagenrules
 %attr(644,root,root) %{_mandir}/man8/*
 %attr(644,root,root) %{_mandir}/man5/*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,6 +72,15 @@ libfapolicyd_la_SOURCES += \
 	library/filter.c \
 	library/filter.h
 
+sbin_PROGRAMS += fapolicyd-rpm-loader
+
+fapolicyd_rpm_loader_SOURCES = \
+	handler/fapolicyd-rpm-loader.c
+
+fapolicyd_rpm_loader_CFLAGS = $(fapolicyd_CFLAGS)
+fapolicyd_rpm_loader_LDFLAGS = $(fapolicyd_LDFLAGS)
+
+fapolicyd_rpm_loader_LDADD = libfapolicyd.la
 endif
 
 if WITH_DEB

--- a/src/daemon/fapolicyd.c
+++ b/src/daemon/fapolicyd.c
@@ -106,17 +106,19 @@ static void install_syscall_filter(void)
 	ctx = seccomp_init(SCMP_ACT_ALLOW);
 	if (ctx == NULL)
 		goto err_out;
-
+#ifndef USE_RPM
 	rc = seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EACCES),
 				SCMP_SYS(execve), 0);
 	if (rc < 0)
 		goto err_out;
-#ifdef HAVE_FEXECVE
-# ifdef __NR_fexecve
+
+# ifdef HAVE_FEXECVE
+#  ifdef __NR_fexecve
 	rc = seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EACCES),
 				SCMP_SYS(fexecve), 0);
 	if (rc < 0)
 		goto err_out;
+#  endif
 # endif
 #endif
 	rc = seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EIO),

--- a/src/handler/fapolicyd-rpm-loader.c
+++ b/src/handler/fapolicyd-rpm-loader.c
@@ -1,0 +1,85 @@
+/*
+ * fapolicy-rpm-loader.c - loader tool for fapolicyd
+ * Copyright (c) 2025-2025 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Radovan Sroka <rsroka@redhat.com>
+ */
+
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+#include <sys/syslog.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <ctype.h>
+#include <magic.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <stdatomic.h>
+#include <lmdb.h>
+#include <limits.h>
+#include <signal.h>
+
+#include "backend-manager.h"
+#include "daemon-config.h"
+#include "message.h"
+#include "llist.h"
+#include "fd-fgets.h"
+#include "paths.h"
+
+volatile atomic_bool stop = 0;  // Library needs this
+unsigned int debug_mode = 0;			// Library needs this
+unsigned int permissive = 0;			// Library needs this
+
+
+int do_rpm_init_backend(void);
+int do_rpm_load_list(conf_t * conf);
+int do_rpm_destroy_backend(void);
+
+extern backend rpm_backend;
+
+int main(int argc, char * const argv[])
+{
+
+	set_message_mode(MSG_STDERR, DBG_YES);
+
+	conf_t config;
+
+	load_daemon_config(&config);
+
+	do_rpm_init_backend();
+	do_rpm_load_list(&config);
+
+	msg(LOG_INFO, "Loaded files %ld", rpm_backend.list.count);
+
+	list_item_t *item = list_get_first(&rpm_backend.list);
+	for (; item != NULL; item = item->next) {
+		printf("%s %s\n", (const char*)item->index, (const char*)item->data);
+	}
+
+	do_rpm_destroy_backend();
+
+	free_daemon_config(&config);
+	return 0;
+}
+


### PR DESCRIPTION
Fix rpmdb locking issues by loading via separate process

SQLite POSIX locks are bound to PIDs. When accessing rpmdb, both
librpm (used by the fapolicyd daemon) and the fanotify file
descriptors may open the database concurrently. If the fanotify FD
is closed directly, the lock is released even though librpm still
has the DB open, potentially leading to a malformed database state.

A previous workaround attempted to store the FD in a buffer:
https://github.com/linux-application-whitelisting/fapolicyd/commit/23fef4ca19ac49dd73f93362fcb51c05c3f4c580
However, this caused the daemon to read outdated or corrupted versions
of the rpmdb.

This patch expects that workaround is reverted that workaround and introduces a proper fix:

- A new binary, `fapolicyd-rpm-loader`, is introduced.
- This binary is spawned as a separate process when rpmdb needs to be
  reloaded.
- It reads the rpmdb and sends the data back to the daemon via a pipe.
- Because this happens under a separate PID, it avoids conflicts
  with SQLite's PID-bound locks.

This is the only reliable and safe way to reload rpmdb without risking
database corruption or inconsistent reads due to PID-based locking.