### PR TITLE
Ignore /var/log/journal to avoid deadlock

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,7 @@ if test $perm = "no"; then
 	AC_MSG_ERROR([FAN_OPEN_EXEC_PERM is not defined in linux/fanotify.h. It is required for the kernel to support it])
 fi
 AC_CHECK_DECLS([FAN_MARK_FILESYSTEM], [], [], [[#include <linux/fanotify.h>]])
+AC_CHECK_DECLS([FAN_MARK_IGNORE], [], [], [[#include <linux/fanotify.h>]])
 
 withval=""
 AC_ARG_WITH(rpm,


### PR DESCRIPTION
This is needed to prevent a possible deadlock with sd-journald while rotating journal files.

When sd-journald rotates journal files with a persistent journal enabled, it needs to create new files in /var/log/journal, which in turn must request access from fapolicyd. However if the fapolicyd queue is full it just logs a message to syslog, including in permissive mode, which may itself block if sd-journald is waiting for access to the fresh journal file and the message queue becomes full. The result is a system wide deadlock between fapolicyd and sd-journald that prevents all watched file accesses, even in permissive mode.

We cannot receive events to inspect the origin or file when the fanotify queue is full, so as a last resort, the /var/log/journal directory must be excluded from supervision to avoid a deadlock. This requires FAN_MARK_IGNORE | FAN_EVENT_ON_CHILD to ignore events beneath /var/log/journal when there is not a suitable mount point to demarc the extent of fapolicyd's supervision.