### PR TITLE
Fix null argv when spawning fapolicyd-rpm-loader

### DIFF
--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -272,7 +272,7 @@ static int rpm_load_list(const conf_t *conf)
 	posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
 	posix_spawn_file_actions_addclose(&actions, pipefd[1]);
 
-	char *argv[] = { "", NULL };
+	char *argv[] = { "fapolicyd-rpm-loader", NULL };
 	char *custom_env[] = { NULL };
 
 	pid_t pid = -1;

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -272,7 +272,7 @@ static int rpm_load_list(const conf_t *conf)
 	posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
 	posix_spawn_file_actions_addclose(&actions, pipefd[1]);
 
-	char *argv[] = { NULL };
+	char *argv[] = { "", NULL };
 	char *custom_env[] = { NULL };
 
 	pid_t pid = -1;


### PR DESCRIPTION
On startup the kernel prints a warning that:

process 'fapolicyd' launched '/usr/sbin/fapolicyd-rpm-loader' with NULL argv: empty string added

Conventionally the first argument to argv should be the name of the program, and the kernel prints a warning whenever this is not the case.

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dcd46d897adb70d63e025f175a00a89797d31a43

fapolicyd-rpm-loader doesn't use any of its arguments, but add an empty string to argv anyway to silence the kernel warning.