### PR TITLE
fd-fgets.c: drop unused #include "libaudit.h"

### DIFF
--- a/src/library/fd-fgets.c
+++ b/src/library/fd-fgets.c
@@ -27,7 +27,6 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/mman.h>
-#include "libaudit.h"
 #include "fd-fgets.h"
 
 /*


### PR DESCRIPTION
It was introduces in commit 0ef8bcc044ef ("Update fd_fgets code") but there's apparently no use for it.

Fixes:

    $ make
    libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -I.. -I../src/library -DPIE -pthread -g -W -Wall -Wshadow -Wundef -Wno-unused-result -Wno-unused-parameter -D_GNU_SOURCE -g -O2 -c library/fd-fgets.c -fPIE -o library/libfapolicyd_la-fd-fgets.o
    library/fd-fgets.c:30:10: fatal error: libaudit.h: No such file or directory
       30 | #include "libaudit.h"
          |          ^~~~~~~~~~~~
    compilation terminated.