### PR TITLE
Do not exit in do_database_reload when stop in progress

### DIFF
--- a/src/library/database.c
+++ b/src/library/database.c
@@ -1267,6 +1267,9 @@ static void do_reload_db(conf_t* config)
 	if ((rc = update_database(config))) {
 		msg(LOG_ERR,
 			"Cannot update trust database!");
+		if (stop)
+			goto out;
+
 		close(ffd[0].fd);
 		backend_close();
 		unlink_fifo();
@@ -1275,6 +1278,7 @@ static void do_reload_db(conf_t* config)
 
 	msg(LOG_INFO, "Updated");
 
+out:
 	// Conserve memory
 	backend_close();
 }


### PR DESCRIPTION
Commit 36c13aca2cbf9 ("Improve update thread synchronization in fapolicyd") added check whether stop is progress. But in corner cases when stop was in progress and there's a request for update trust db, fapolicyd exited with error.

Fixes:
    # kill $(pidof fapolicyd) & fapolicyd-cli --update

    [ ERROR ]: Cannot update trust database!
    fapolicyd.service: Main process exited, code=exited, status=1/FAILURE
    fapolicyd.service: Failed with result 'exit-code'.