### PR TITLE
Some excluded mounts should not be excluded

### DIFF
--- a/src/daemon/fapolicyd.c
+++ b/src/daemon/fapolicyd.c
@@ -457,7 +457,7 @@ static int check_mount_entry(const char *point, const char *type)
 	// Some we know we don't want
 	if (strcmp(point, "/run") == 0)
 		return 0;
-	if (strncmp(point, "/sys", 4) == 0)
+	if (strncmp(point, "/sys/", 5) == 0)
 		return 0;
 
 	if (find_filesystem(&filesystems, type))

--- a/src/daemon/fapolicyd.c
+++ b/src/daemon/fapolicyd.c
@@ -455,8 +455,6 @@ static int check_mount_entry(const char *point, const char *type)
 		return 0;
 
 	// Some we know we don't want
-	if (strcmp(point, "/run") == 0)
-		return 0;
 	if (strncmp(point, "/sys/", 5) == 0)
 		return 0;
 


### PR DESCRIPTION
IMHO it's not correct to exclude `/run` because some users may be able to write to some subdir.
Also, `/sys*` should not be excluded at all, otherwise mount points such as `/system` are being excluded as well.