### PR TITLE
point to the new repo with fapolicyd tests

### DIFF
--- a/CI/ci-tests.fmf
+++ b/CI/ci-tests.fmf
@@ -1,6 +1,6 @@
 discover:
     how: fmf
-    url: https://github.com/RedHat-SP-Security/fapolicyd-tests.git
+    url: https://github.com/linux-application-whitelisting/fapolicyd-tests.git
     filter: component:fapolicyd & tag:CI-Tier-1
 execute:
     how: tmt


### PR DESCRIPTION
The following repository is archived and read-only:
 * https://github.com/RedHat-SP-Security/fapolicyd-tests

The new repository for fapolicyd tests is located at:
 * https://github.com/linux-application-whitelisting/fapolicyd-tests

All plans and tests should count with that.