### PR TITLE
Files with checksum excluded from %verify should be ignored

### DIFF
--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -185,6 +185,15 @@ static int is_config_rpm(void)
 	return 0;
 }
 
+/* Files with checksum excluded from %verify should be ignored */
+static int is_checksum_ignored_rpm(void)
+{
+	if (rpmfiVFlags(fi) & RPMVERIFY_FILEDIGEST) {
+		return 0;
+	}
+	return 1;
+}
+
 static void close_rpm(void)
 {
 	rpmfiFree(fi);
@@ -326,6 +335,10 @@ int do_rpm_load_list(const conf_t *conf, int memfd)
 			if (is_config_rpm())
 				continue;
 
+			// We do not want any files excluded from verifying checksum in database
+			if (is_checksum_ignored_rpm()) {
+				continue;
+			}
 			// Get specific file information
 			const char *tmp = get_file_name_rpm();
 


### PR DESCRIPTION
Some files owner by an rpm are expected to be changed while they're still owned by the package, e.g. redhat-rpm-config.spec contains:

    %verify(owner group mode) %{rrcdir}/redhat-annobin-cc1

or selinux-policy.spec a lot of files like:

    %verify(not md5 size mtime) %{_sysconfdir}/selinux/%1/policy/policy.%{POLICYVER}

Such files can't be verified and therefore should not be in trustdb.

Fixes:

    $ sudo fapolicyd-cli --check-trustdb
    /etc/selinux/targeted/contexts/files/file_contexts miscompares: size sha256
    /etc/selinux/targeted/contexts/files/file_contexts.homedirs miscompares: size sha256
    /etc/selinux/targeted/policy/policy.35 miscompares: size sha256
    /usr/bin/ld miscompares: size sha256
    /usr/lib/rpm/redhat/redhat-annobin-cc1 miscompares: size sha256
    /usr/lib64/gconv/gconv-modules.cache miscompares: size sha256
    /var/lib/selinux/targeted/active/commit_num miscompares:  sha256
    /var/lib/selinux/targeted/active/file_contexts miscompares: size sha256
    /var/lib/selinux/targeted/active/file_contexts.homedirs miscompares: size sha256
    /var/lib/selinux/targeted/active/homedir_template miscompares: size sha256
    /var/lib/selinux/targeted/active/modules_checksum miscompares:  sha256
    /var/lib/selinux/targeted/active/policy.kern miscompares: size sha256