### PR TITLE
Add files in /usr/share/*/bin/* to trust db

### DIFF
--- a/init/fapolicyd-filter.conf
+++ b/init/fapolicyd-filter.conf
@@ -31,6 +31,8 @@
   + *.py?
   # Python text files
   + *.py
+  # Some apps have a private bin
+  + */bin/*
   # Some apps have a private libexec
   + */libexec/*
   # Ruby


### PR DESCRIPTION
On RHEL8 and Fedora 42 at least, there are scripts or binaries living in `/usr/share/*/bin/*`:

~~~
(rhel8) # find /usr/share -type f | grep /bin/
/usr/share/doc/perl-Mail-SPF/bin/spfquery
/usr/share/sgml/docbook/xsl-stylesheets-1.79.2/epub/bin/dbtoepub
/usr/share/Modules/bin/add.modules
/usr/share/Modules/bin/createmodule.sh
/usr/share/Modules/bin/mkroot
[...]

(fedora42) # find /usr/share -type f | grep /bin/
/usr/share/gems/gems/syslog-0.2.0/bin/setup
/usr/share/gems/gems/syslog-0.2.0/bin/console
/usr/share/gems/gems/resolv-replace-0.1.1/bin/setup
/usr/share/gems/gems/resolv-replace-0.1.1/bin/console /usr/share/gems/gems/rinda-0.2.0/bin/setup
/usr/share/gems/gems/rinda-0.2.0/bin/console
/usr/share/gems/gems/nkf-0.2.0/bin/setup
/usr/share/gems/gems/nkf-0.2.0/bin/console
/usr/share/gems/gems/getoptlong-0.2.1/bin/setup
/usr/share/gems/gems/getoptlong-0.2.1/bin/console
/usr/share/gems/gems/abbrev-0.1.2/bin/setup
/usr/share/gems/gems/abbrev-0.1.2/bin/console
/usr/share/gems/gems/observer-0.1.2/bin/setup
/usr/share/gems/gems/observer-0.1.2/bin/console
/usr/share/sgml/docbook/xsl-stylesheets-1.79.2/epub/bin/dbtoepub
[...]
~~~