### PR TITLE
Don't skip the path when reopening as ld.so

### DIFF
--- a/src/library/event.c
+++ b/src/library/event.c
@@ -283,14 +283,15 @@ int new_event(const struct fanotify_event_metadata *m, event_t *e)
 		// because it was collected on perm = execute.
 		if ((s->info->state == STATE_COLLECTING) &&
 			(e->type & FAN_OPEN_PERM) && !rc) {
-			skip_path = 1;
-			s->info->state = STATE_REOPEN;
-
 			// special branch after ld_so exec
 			// next opens will go fall trough
 			if (s->info->path1 &&
 				(strcmp(s->info->path1, SYSTEM_LD_SO) == 0))
 				s->info->state = STATE_DEFAULT_REOPEN;
+			else {
+				skip_path = 1;
+				s->info->state = STATE_REOPEN;
+			}
 		}
 
 		// If not same proc or we detect execution, evict


### PR DESCRIPTION
When *not* having the `ld_so` rule (`deny_audit perm=any pattern=ld_so : all`), executing something through the linker shows wrong executable in the fapolicyd log, as seen in the example below:

### Command

~~~
(user) $ cp /bin/ls ~/
(user) $ /usr/lib64/ld-linux-x86-64.so.2 ./ls
ls
~~~

### Log

~~~
12/01/2025 14:29:04 [ DEBUG ]: rule=8 dec=allow perm=execute auid=1000 pid=44600 exe=/usr/bin/bash : path=/usr/lib64/ld-linux-x86-64.so.2 ftype=application/x-sharedlib trust=1
12/01/2025 14:29:04 [ DEBUG ]: rule=6 dec=allow perm=open auid=1000 pid=44600 exe=/usr/bin/bash : path=/usr/lib64/ld-linux-x86-64.so.2 ftype=application/x-sharedlib trust=1

HERE IT'S WRONG:
12/01/2025 14:29:04 [ DEBUG ]: rule=13 dec=allow perm=open auid=1000 pid=44600 exe=/usr/bin/bash : path=/home/user/ls ftype=application/x-executable trust=0

12/01/2025 14:29:04 [ DEBUG ]: rule=13 dec=allow perm=open auid=1000 pid=44600 exe=/usr/lib64/ld-linux-x86-64.so.2 : path=/etc/ld.so.cache ftype=application/octet-stream trust=0
12/01/2025 14:29:04 [ DEBUG ]: rule=6 dec=allow perm=open auid=1000 pid=44600 exe=/usr/lib64/ld-linux-x86-64.so.2 : path=/usr/lib64/libselinux.so.1 ftype=application/x-sharedlib trust=1
 :
~~~

Here above third line show `exec=/usr/bin/bash` while it should show `exe=/usr/lib64/ld-linux-x86-64.so.2`.

The reason for this is there is a `skip_path` being set while it should not.
With this patch, we get the expected executable name, as shown below.

### Log once patch applied

~~~
12/01/2025 14:30:46 [ DEBUG ]: rule=8 dec=allow perm=execute auid=1000 pid=45425 exe=/usr/bin/bash : path=/usr/lib64/ld-linux-x86-64.so.2 ftype=application/x-sharedlib trust=1
12/01/2025 14:30:46 [ DEBUG ]: rule=6 dec=allow perm=open auid=1000 pid=45425 exe=/usr/bin/bash : path=/usr/lib64/ld-linux-x86-64.so.2 ftype=application/x-sharedlib trust=1

HERE:
12/01/2025 14:30:46 [ DEBUG ]: rule=13 dec=allow perm=open auid=1000 pid=45425 exe=/usr/lib64/ld-linux-x86-64.so.2 : path=/home/user/ls ftype=application/x-executable trust=0

12/01/2025 14:30:46 [ DEBUG ]: rule=13 dec=allow perm=open auid=1000 pid=45425 exe=/usr/lib64/ld-linux-x86-64.so.2 : path=/etc/ld.so.cache ftype=application/octet-stream trust=0
12/01/2025 14:30:46 [ DEBUG ]: rule=6 dec=allow perm=open auid=1000 pid=45425 exe=/usr/lib64/ld-linux-x86-64.so.2 : path=/usr/lib64/libselinux.so.1 ftype=application/x-sharedlib trust=1
 :
~~~
