### PR TITLE
Fix binary path of rpm-loader

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -84,6 +84,7 @@ bin_PROGRAMS = fapolicyd-rpm-loader
 fapolicyd_rpm_loader_SOURCES = \
 	handler/fapolicyd-rpm-loader.c
 
+fapolicyd_CFLAGS += -DBINARYDIR='"$(bindir)"'
 fapolicyd_rpm_loader_CFLAGS = $(fapolicyd_CFLAGS)
 fapolicyd_rpm_loader_LDFLAGS = $(fapolicyd_LDFLAGS)
 fapolicyd_rpm_loader_LDADD = libfapolicyd.la

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -238,7 +238,7 @@ static int rpm_load_list(const conf_t *conf)
 	char *custom_env[] = { "FAPO_SOCK_FD=3", NULL };
 
 	pid_t pid = -1;
-	int status = posix_spawn(&pid, "/usr/bin/fapolicyd-rpm-loader",
+	int status = posix_spawn(&pid, BINARYDIR "/fapolicyd-rpm-loader",
 					 &actions, NULL, argv, custom_env);
 	close(sv[1]);  // Parent doesn't write
 


### PR DESCRIPTION
When compiling with a prefix such as `/usr/local/bin`, the spawn of `fapolicyd-rpm-loader` fails because the path is hardcoded to `/usr/bin`.
This patch fixes this issue.