### PR TITLE
Add a CLI tool for measuring performance

### DIFF
--- a/.github/workflows/.rawhide-fedora-build
+++ b/.github/workflows/.rawhide-fedora-build
@@ -27,7 +27,7 @@ jobs:
       run: ./autogen.sh
 
     - name: configure
-      run: ./configure --with-rpm --with-audit --disable-shared --disable-dependency-tracking
+      run: ./configure --with-perf-test --with-rpm --with-audit --disable-shared --disable-dependency-tracking
 
     - name: build
       run: make

--- a/.github/workflows/almalinux9.yml
+++ b/.github/workflows/almalinux9.yml
@@ -30,7 +30,7 @@ jobs:
       run: ./autogen.sh
 
     - name: configure
-      run: ./configure --with-rpm --with-audit --disable-shared --disable-dependency-tracking
+      run: ./configure --with-perf-test --with-rpm --with-audit --disable-shared --disable-dependency-tracking
 
     - name: build
       run: make

--- a/.github/workflows/centosstream10.yml
+++ b/.github/workflows/centosstream10.yml
@@ -30,7 +30,7 @@ jobs:
       run: ./autogen.sh
 
     - name: configure
-      run: ./configure --with-rpm --with-audit --disable-shared --disable-dependency-tracking
+      run: ./configure --with-perf-test --with-rpm --with-audit --disable-shared --disable-dependency-tracking
 
     - name: build
       run: make

--- a/.github/workflows/rockylinux9.yml
+++ b/.github/workflows/rockylinux9.yml
@@ -30,7 +30,7 @@ jobs:
       run: ./autogen.sh
 
     - name: configure
-      run: ./configure --with-rpm --with-audit --disable-shared --disable-dependency-tracking
+      run: ./configure --with-perf-test --with-rpm --with-audit --disable-shared --disable-dependency-tracking
 
     - name: build
       run: make

--- a/.github/workflows/stable-fedora-build.yml
+++ b/.github/workflows/stable-fedora-build.yml
@@ -27,7 +27,7 @@ jobs:
       run: ./autogen.sh
 
     - name: configure
-      run: ./configure --with-rpm --with-audit --disable-shared --disable-dependency-tracking
+      run: ./configure --with-perf-test --with-rpm --with-audit --disable-shared --disable-dependency-tracking
 
     - name: build
       run: make

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -33,7 +33,7 @@ jobs:
       run: ./autogen.sh
 
     - name: configure
-      run: ./configure --without-rpm --with-audit --disable-shared --disable-dependency-tracking --with-deb
+      run: ./configure --with-perf-test --without-rpm --with-audit --disable-shared --disable-dependency-tracking --with-deb
 
     - name: build
       run: make

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ Makefile
 init/fapolicyd-magic.mgc
 src/fapolicyd
 src/fapolicyd-cli
+src/fapolicyd-perf-test
 src/fapolicyd-rpm-loader
 
 *.log

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,12 @@ AM_CONDITIONAL(WITH_DEB, test x$use_deb = xyes)
 
 AM_CONDITIONAL(NEED_MD5, test x$use_deb = xyes)
 
+withval=""
+AC_ARG_WITH(perf-test,
+AS_HELP_STRING([--with-perf-test],[Build and install a performance test utility]),
+use_perf_test=$withval,use_perf_test=no)
+AM_CONDITIONAL(WITH_PERF_TEST, test x$use_perf_test = xyes)
+
 dnl FIXME some day pass this on the command line
 def_systemdsystemunitdir=${prefix}/lib/systemd/system
 AC_SUBST([systemdsystemunitdir], [$def_systemdsystemunitdir])

--- a/doc/fapolicyd-perf-test.8
+++ b/doc/fapolicyd-perf-test.8
@@ -1,0 +1,41 @@
+.TH "FAPOLICYD-PERF-TEST" "26" "Mar 2026" "Red Hat" "System Administration Utilities"
+.SH NAME
+fapolicyd-perf-test \- Fapolicyd Performance Test Utility
+.SH SYNOPSIS
+\fBfapolicyd-perf-test\fP [\fIINPUT_FILE\fP]
+.SH DESCRIPTION
+Runs a dummy fapolicyd policy decision on each file from newline-separated
+list read from INPUT_FILE (or stdin if not specified) and prints the total
+time it took.
+.SH RETURN CODES
+The following exit status values are used for error reporting and scripting:
+.TP
+.B 0  Success
+Normal completion.
+.TP
+.B 1  Generic/unspecified failure
+Fallback for errors that do not map to a more specific category.
+.TP
+.B 2  CLI/usage error
+Incorrect options or argument counts.
+.SH EXAMPLE USAGE
+.nf
+\fB# touch file-list.txt\fP
+\fB# find /usr/lib64 -type f >>file-list.txt\fP
+\fB# find /usr/bin   -type f >>file-list.txt\fP
+\fB# find /usr/share -type f >>file-list.txt\fP
+\fB# wc -l file-list.txt\fP
+15080 file-list.txt
+\fB# fapolicyd-perf-test file-list.txt 2>/dev/null\fP
+Starting scan...
+Elapsed: 0 seconds, 58 milliseconds
+\fB# \fP
+.fi
+.SH "SEE ALSO"
+.BR fapolicyd (8),
+.BR fapolicyd-cli (8),
+and
+.BR fapolicyd.conf (5)
+
+.SH AUTHOR
+Ondrej Mosnacek

--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -116,7 +116,7 @@ EOF
 
 %build
 ./autogen.sh
-configure_flags="--with-audit --with-rpm --disable-shared"
+configure_flags="--with-perf-test --with-audit --with-rpm --disable-shared"
 
 %if %{defined asan_build}
 configure_flags="$configure_flags --with-asan"
@@ -269,6 +269,7 @@ fi
 %attr(644,root,root) %{_tmpfilesdir}/%{name}.conf
 %attr(755,root,root) %{_sbindir}/%{name}
 %attr(755,root,root) %{_sbindir}/%{name}-cli
+%attr(755,root,root) %{_sbindir}/%{name}-perf-test
 %attr(755,root,root) %{_bindir}/%{name}-rpm-loader
 %attr(755,root,root) %{_sbindir}/fagenrules
 %attr(644,root,root) %{_mandir}/man8/*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,10 @@ AM_CPPFLAGS = \
 check-recursive: libfapolicyd.la
 
 sbin_PROGRAMS = fapolicyd fapolicyd-cli
+if WITH_PERF_TEST
+sbin_PROGRAMS += fapolicyd-perf-test
+endif
+
 lib_LTLIBRARIES= libfapolicyd.la
 
 fapolicyd_CFLAGS = -std=gnu11 -fPIE -DPIE -pthread -g -W -Wall -Wshadow -Wundef -Wno-unused-result -Wno-unused-parameter -D_GNU_SOURCE
@@ -17,6 +21,12 @@ fapolicyd_LDADD = libfapolicyd.la
 fapolicyd_cli_CFLAGS = $(fapolicyd_CFLAGS)
 fapolicyd_cli_LDFLAGS = $(fapolicyd_LDFLAGS)
 fapolicyd_cli_LDADD = libfapolicyd.la
+
+if WITH_PERF_TEST
+fapolicyd_perf_test_CFLAGS = $(fapolicyd_CFLAGS)
+fapolicyd_perf_test_LDFLAGS = $(fapolicyd_LDFLAGS)
+fapolicyd_perf_test_LDADD = libfapolicyd.la
+endif
 
 libfapolicyd_la_SOURCES = \
 	library/avl.c \
@@ -117,3 +127,8 @@ fapolicyd_cli_SOURCES = \
 	cli/fapolicyd-cli.c \
 	cli/file-cli.c \
 	cli/file-cli.h
+
+if WITH_PERF_TEST
+fapolicyd_perf_test_SOURCES = \
+	perf-test/fapolicyd-perf-test.c
+endif

--- a/src/perf-test/fapolicyd-perf-test.c
+++ b/src/perf-test/fapolicyd-perf-test.c
@@ -1,0 +1,172 @@
+/*
+ * fapolicyd-perf-test.c - fapolicyd performance testing tool
+ * Copyright (c) 2025-2026 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This software may be freely redistributed and/or modified under the
+ * terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1335, USA.
+ *
+ * Authors:
+ *   Steve Grubb <sgrubb@redhat.com>
+ *   Ondrej Mosnacek <omosnace@redhat.com>
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdatomic.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/time.h>
+
+#include "config.h"
+
+#include "daemon-config.h"
+#include "message.h"
+#include "policy.h"
+#include "database.h"
+
+/* These need to be defined for the library */
+atomic_bool stop = 0;
+unsigned int debug_mode = 0;
+conf_t config = {};
+
+static char *get_line(FILE *f)
+{
+	char *line = NULL;
+	size_t len = 0;
+
+	while (getline(&line, &len, f) != -1) {
+		/* remove newline */
+		char *ptr = strchr(line, 0x0a);
+		if (ptr)
+			*ptr = 0;
+		return line;
+	}
+	free(line);
+	return NULL;
+}
+
+static int do_perf_test(FILE *input)
+{
+	int rc = 0, resp_fd;
+	pid_t our_pid;
+	struct timeval t0, t1;
+	char *path;
+
+	set_message_mode(MSG_STDERR, DBG_NO);
+	if (load_daemon_config(&config)) {
+		rc = 1;
+		goto out_reset_config;
+	}
+	if (load_rules(&config)) {
+		rc = 1;
+		goto out_reset_config;
+	}
+	// Setup lru caches
+	if (init_event_system(&config)) {
+		rc = 1;
+		goto out_rules;
+	}
+	if (init_database(&config)) {
+		rc = 1;
+		goto out_event_system;
+	}
+	// Init the file test libraries
+	file_init();
+	// Don't let it accidently emit audit events
+	policy_no_audit();
+
+	resp_fd = open("/dev/null", O_WRONLY|O_CLOEXEC);
+	if (resp_fd < 0) {
+		fprintf(stderr, "Can't open dev null\n");
+		rc = 1;
+		goto out_file;
+	}
+
+	our_pid = getpid();
+	printf("Starting scan...\n");
+
+	gettimeofday(&t0, NULL);
+	while ((path = get_line(input))) {
+		int fd = open(path, O_RDONLY|O_CLOEXEC);
+		free(path);
+		if (fd < 0)
+			continue;
+		// Build an "event" to exercise fapolicyd's decision making
+		struct fanotify_event_metadata metadata;
+		metadata.fd = fd; // listener closes after reply
+		metadata.pid = our_pid;
+		metadata.mask = FAN_OPEN_PERM;
+
+		make_policy_decision(&metadata, resp_fd, FAN_OPEN_PERM | FAN_OPEN_EXEC_PERM);
+	}
+	stop = 1;
+	gettimeofday(&t1, NULL);
+
+	long sec  = t1.tv_sec  - t0.tv_sec;
+	long usec = t1.tv_usec - t0.tv_usec;
+	if (usec < 0) {
+		usec += 1000000;
+		sec--;
+	}
+	long msec = usec / 1000;
+	printf("Elapsed: %ld seconds, %ld milliseconds\n", sec, msec);
+
+	close(resp_fd);
+out_file:
+	file_close();
+	close_database();
+out_event_system:
+	destroy_event_system();
+	unlink_fifo();
+out_rules:
+	destroy_rules();
+out_reset_config:
+	free_daemon_config(&config);
+	return rc;
+}
+
+static const char *USAGE =
+"Fapolicyd Performace Test\n\n"
+"Usage: %s [INPUT_FILE]\n\n"
+"Runs a dummy fapolicyd policy decision on each file from newline-separated\n"
+"list read from INPUT_FILE (or stdin if not specified) and prints the total"
+"time it took.\n"
+;
+
+int main(int argc, char * const argv[])
+{
+	FILE *input = stdin;
+	int rc;
+
+	if (argc > 2) {
+		printf(USAGE, argv[0]);
+		return 2;
+	}
+
+	if (argc > 1) {
+		input = fopen(argv[1], "r");
+		if (input == NULL) {
+			fprintf(stderr, "Error opening input file\n");
+			return 1;
+		}
+	}
+
+	rc = do_perf_test(input);
+	if (input != stdin)
+		fclose(input);
+	return rc;
+}


### PR DESCRIPTION
This takes the test-driver program from fapolicyd-extras [1] and
integrates it into fapolicyd sources as a standalone fapolicyd-perf-test
CLI tool. It can be used to measure performance of fapolicyd access
decisions.

Building the tool is disabled by default and can be enabled by passing
--with-perf-test to ./configure. Distributions can decide if they want
to ship the tool as a separate subpackage, or if they want to build it
at all.

Example usage:

    # touch file-list.txt
    # find /usr/lib64 -type f >>file-list.txt
    # find /usr/bin   -type f >>file-list.txt
    # find /usr/share -type f >>file-list.txt
    # wc -l file-list.txt
    15080 file-list.txt
    # fapolicyd-perf-test file-list.txt 2>/dev/null
    Starting scan...
    Elapsed: 0 seconds, 58 milliseconds
    #

Running "perf record" from the test is not preserved, but similar result
can be achieved by running the tool under perf:

    # perf record --call-graph dwarf fapolicyd-perf-test file-list.txt
    ...
    # perf script/report ...

[1] https://github.com/linux-application-whitelisting/fapolicyd-extras/blob/main/performance/test-driver.c