### PR TITLE
Add `fapolicyd-cli --check-rules path` and use it in `fagenrules`

### DIFF
--- a/doc/fapolicyd-cli.8
+++ b/doc/fapolicyd-cli.8
@@ -33,6 +33,9 @@ matching the \fB%languages\fP macro. Any matches are reported and a summary per
 mount is displayed. A non-zero status is returned when suspicious files are
 found so automated workflows can gate changes.
 .TP
+.B \-\-check-rules path
+Parse the rules file and validate its syntax without loading it into the daemon. A zero exit status means the file is valid.
+.TP
 .B \-d, \-\-delete-db
 Deletes the trust database. Normally this never needs to be done. But if for some reason the trust database becomes corrupted, then the only method of recovery is to run this command.
 .TP

--- a/init/fagenrules
+++ b/init/fagenrules
@@ -97,6 +97,15 @@ END     {
         for (i = 0; i < rest; i++) { printf "%s\n", rules[i]; }
 }' >> "${TmpRules}"
 
+fapolicyd-cli --check-rules "${TmpRules}"
+err=$?
+if [ $err -ne 0 ]; then
+    echo "Rules file content:"
+    cat -n "${TmpRules}"
+    rm -f "${TmpRules}"
+    exit $err
+fi
+
 # If the same then quit
 cmp -s "${TmpRules}" ${DestinationFile} > /dev/null 2>&1
 if [ $? -eq 0 ]; then

--- a/init/fapolicyd.bash_completion
+++ b/init/fapolicyd.bash_completion
@@ -7,7 +7,7 @@ _fapolicydcli()
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="--check-config --check-path --check-status --check-trustdb \
+	opts="--check-config --check-path --check-rules --check-status --check-trustdb \
 		--check-watch_fs --check-ignore_mounts --delete-db --dump-db \
 		--file --filter --ftype --help --list --update --reload-rules \
 		--test-filter --trust-file --verbose -h -d -D -f -t -l -u -r"
@@ -108,6 +108,15 @@ _fapolicydcli()
 			return 0
 		;;
 		--filter)
+			if [ -e /usr/share/bash-completion/bash_completion ] ; then
+				_filedir
+			else
+				compopt -o filenames 2>/dev/null
+				COMPREPLY=( $(compgen -f -- ${cur}) )
+			fi
+			return 0
+		;;
+		--check-rules)
 			if [ -e /usr/share/bash-completion/bash_completion ] ; then
 				_filedir
 			else

--- a/src/cli/fapolicyd-cli.c
+++ b/src/cli/fapolicyd-cli.c
@@ -45,6 +45,7 @@
 #include <mntent.h>
 #include <libgen.h>	// basename
 #include "policy.h"
+#include "rules.h"
 #include "database.h"
 #include "file-cli.h"
 #include "file.h"
@@ -69,6 +70,7 @@ static const char *usage =
 "--check-trustdb       Check the trustdb against files on disk for problems\n"
 "--check-watch_fs      Check watch_fs against currently mounted file systems\n"
 "--check-ignore_mounts [path] Scan ignored mounts for executable content\n"
+"--check-rules path    Validate rules file syntax without loading\n"
 "--verbose             Enable verbose output for select commands\n"
 "-d, --delete-db       Delete the trust database\n"
 "-D, --dump-db         Dump the trust database contents\n"
@@ -94,6 +96,7 @@ static struct option long_opts[] =
 	{"check-trustdb",0, NULL,  3 },
 	{"check-status",0, NULL,  4 },
 	{"check-path",  0, NULL,  5 },
+	{"check-rules",  1, NULL, 9 },
 	{"delete-db",	0, NULL, 'd'},
 	{"dump-db",	0, NULL, 'D'},
 	{"file",	1, NULL, 'f'},
@@ -1194,6 +1197,75 @@ finish:
 	return rc;
 }
 
+static int check_rules_file(const char *path)
+{
+	FILE *f;
+	int rc, lineno = 1, invalid = 0;
+	char *line = NULL;
+	llist temp_rules;
+
+	// Set message mode to stderr so error messages are visible
+	set_message_mode(MSG_STDERR, DBG_NO);
+
+	// Initialize attribute sets (needed for %set parsing)
+	if (init_attr_sets()) {
+		fprintf(stderr, "Failed to initialize attribute sets\n");
+		return CLI_EXIT_INTERNAL;
+	}
+
+	// Open the specified rules file
+	f = fopen(path, "r");
+	if (f == NULL) {
+		fprintf(stderr, "Cannot open rules file %s (%s)\n",
+				path, strerror(errno));
+		destroy_attr_sets();
+		return CLI_EXIT_IO;
+	}
+
+	// Create temporary rules list for validation
+	if (rules_create(&temp_rules)) {
+		fprintf(stderr, "Failed to create rules list\n");
+		fclose(f);
+		destroy_attr_sets();
+		return CLI_EXIT_INTERNAL;
+	}
+
+	// Parse each line (same pattern as _load_rules in policy.c)
+	while ((line = get_line(f))) {
+		rc = rules_append(&temp_rules, line, lineno);
+		if (rc) {
+			fprintf(stderr, "Rule validation failed at line %d\n",
+					lineno);
+			invalid = 1;
+		}
+		free(line);
+		lineno++;
+	}
+
+	if (invalid) {
+		rules_clear(&temp_rules);
+		fclose(f);
+		destroy_attr_sets();
+		return CLI_EXIT_RULE_FILTER;
+	}
+
+	// Check for empty rules file
+	if (temp_rules.cnt == 0) {
+		fprintf(stderr, "No rules found in file\n");
+		rules_clear(&temp_rules);
+		fclose(f);
+		destroy_attr_sets();
+		return CLI_EXIT_RULE_FILTER;
+	}
+
+	printf("Rules file is valid (%u rules)\n", temp_rules.cnt);
+	rules_clear(&temp_rules);
+	fclose(f);
+	destroy_attr_sets();
+
+	return CLI_EXIT_SUCCESS;
+}
+
 // Returns 0 = everything is OK, 1 = there is a problem
 static int verify_file(const char *path, off_t size, const char *sha,
 		        unsigned int tsource)
@@ -1603,6 +1675,13 @@ int main(int argc, char * const argv[])
 		if (optind < arg_count)
 			goto args_err;
 		return check_ignore_mounts(override);
+		}
+		break;
+
+	case 9: { // --check-rules
+		if (arg_count > 3)
+			goto args_err;
+		return check_rules_file(optarg);
 		}
 		break;
 

--- a/src/cli/fapolicyd-cli.c
+++ b/src/cli/fapolicyd-cli.c
@@ -128,12 +128,12 @@ struct mount_scan_state {
 
 static struct mount_scan_state scan_state;
 
-static char *get_line(FILE *f, unsigned *lineno)
+static char *get_line(FILE *f)
 {
 	char *line = NULL;
 	size_t len = 0;
 
-	while (getline(&line, &len, f) != -1) {
+	if (getline(&line, &len, f) != -1) {
 		/* remove newline */
 		char *ptr = strchr(line, 0x0a);
 		if (ptr)
@@ -442,7 +442,7 @@ static int do_ftype(const char *path)
 
 static int do_list(void)
 {
-	unsigned count = 1, lineno = 0;
+	unsigned count = 1;
 	FILE *f = fopen(OLD_RULES_FILE, "rm");
 	char *buf;
 
@@ -465,9 +465,8 @@ static int do_list(void)
 		}
 	}
 
-	while ((buf = get_line(f, &lineno))) {
+	while ((buf = get_line(f))) {
 		char *str = buf;
-		lineno++;
 		while (*str) {
 			if (!isblank(*str))
 				break;


### PR DESCRIPTION
When `fagenrules` was run with invalid rules it broke `fapolicyd`
startup, see below.

    # fapolicyd
    04/17/2026 13:52:30 [ INFO ]: Can handle 524288 file descriptors
    04/17/2026 13:52:30 [ INFO ]: Ruleset identity: 8b5126cc76e5372274fdf0024d2d13c274a52cda6611f15a577742bbace2dc99
    04/17/2026 13:52:30 [ NOTICE ]: SHA256HASH object name is deprecated; use FILE_HASH instead
    # killall fapolicyd

    # echo 'a b c' > /etc/fapolicyd/rules.d/99.rules
    # fagenrules
    # fapolicyd
    04/17/2026 13:53:35 [ INFO ]: Can handle 524288 file descriptors
    04/17/2026 13:53:35 [ INFO ]: Ruleset identity: 308521d067909a4e66a429c5fafaf864cfe4071b00ba40ac24d63f2deb7ef36f
    04/17/2026 13:53:35 [ NOTICE ]: SHA256HASH object name is deprecated; use FILE_HASH instead
    04/17/2026 13:53:35 [ ERROR ]: Invalid decision (a) in line 15

With this change, `fapolicyd-cli --check-rules` is used before $TmpRules
are renamed to /etc/fapolicyd/compiled.rules in order to prevent this
behaviour.