### PR TITLE
Disable FAN_FS_ERROR health monitoring even when supported - DO NOT MERGE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,23 @@ if test $perm = "no"; then
 fi
 AC_CHECK_DECLS([FAN_MARK_FILESYSTEM], [], [], [[#include <linux/fanotify.h>]])
 
+AC_ARG_ENABLE(fanotify-fs-error,
+AS_HELP_STRING([--disable-fanotify-fs-error],
+[disable FAN_FS_ERROR health monitoring even when supported]),
+[enable_fanotify_fs_error=$enableval],
+[enable_fanotify_fs_error=yes])
+case x$enable_fanotify_fs_error in
+	xyes)
+		AC_DEFINE([FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR], [1],
+			[Define to enable FAN_FS_ERROR health monitoring])
+		;;
+	xno)
+		;;
+	*)
+		AC_MSG_ERROR([bad value $enableval for --enable-fanotify-fs-error])
+		;;
+esac
+
 withval=""
 AC_ARG_WITH(rpm,
 AS_HELP_STRING([--with-rpm],[Use the rpm database as a trust source]),
@@ -238,5 +255,6 @@ echo "
 `echo $LDFLAGS | fmt -w 50 | sed 's,^,                          ,'`
   __attr_access support:  $ACCESS
   __attr_dealloc_free support: $DEALLOC
+  FAN_FS_ERROR monitoring: $enable_fanotify_fs_error
 "
  

--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -99,7 +99,7 @@ EOF
 
 %build
 ./autogen.sh
-configure_flags="--with-perf-test --with-audit --with-rpm --disable-shared"
+configure_flags="--with-perf-test --with-audit --with-rpm --disable-shared --disable-fanotify-fs-error"
 
 %if %{defined asan_build}
 configure_flags="$configure_flags --with-asan"

--- a/src/daemon/fanotify-fs-error.c
+++ b/src/daemon/fanotify-fs-error.c
@@ -36,9 +36,9 @@
  * queue handled by notify.c.
  *
  * Header and kernel support vary across supported build targets. Public entry
- * points stay available even when FAN_FS_ERROR symbols are absent; in that case
- * initialization reports that monitoring is unavailable and all other helpers
- * become harmless no-ops.
+ * points stay available even when FAN_FS_ERROR symbols are absent or configure
+ * disables this monitor; in that case initialization reports that monitoring is
+ * unavailable and all other helpers become harmless no-ops.
  */
 
 #include "config.h" /* Needed to get O_LARGEFILE definition */
@@ -62,7 +62,8 @@
 #define FANOTIFY_FS_ERROR_BUFFER_SIZE 8192
 #define FS_ERROR_LOG_INTERVAL 60
 
-#if defined(FAN_FS_ERROR) && defined(FAN_REPORT_FID) && \
+#if defined(FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR) && \
+	defined(FAN_FS_ERROR) && defined(FAN_REPORT_FID) && \
 	defined(FAN_MARK_FILESYSTEM) && \
 	defined(FAN_EVENT_INFO_TYPE_ERROR) && \
 	defined(FAN_EVENT_INFO_TYPE_FID)
@@ -599,9 +600,14 @@ void fanotify_fs_error_unmark(const char *path)
 int fanotify_fs_error_init(mlist *m)
 {
 	(void)m;
+#if defined(FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR)
 	msg(LOG_INFO,
 	    "FAN_FS_ERROR monitoring disabled; kernel headers do not provide "
 	    "the required fanotify info records");
+#else
+	msg(LOG_INFO,
+	    "FAN_FS_ERROR monitoring disabled by configure option");
+#endif
 	return -1;
 }
 #endif

--- a/src/tests/notify_test.c
+++ b/src/tests/notify_test.c
@@ -1,6 +1,7 @@
 /*
  * notify_test.c - unit tests for daemon fanotify metadata handling
  */
+#include "config.h"
 #include <error.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -23,7 +24,8 @@
 #define FAN_Q_OVERFLOW		0x00004000
 #endif
 
-#if defined(FAN_FS_ERROR) && defined(FAN_REPORT_FID) && \
+#if defined(FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR) && \
+	defined(FAN_FS_ERROR) && defined(FAN_REPORT_FID) && \
 	defined(FAN_MARK_FILESYSTEM) && \
 	defined(FAN_EVENT_INFO_TYPE_ERROR) && \
 	defined(FAN_EVENT_INFO_TYPE_FID)


### PR DESCRIPTION
Trigger CI to get a better idea how this works with CentOS Stream 10 testsuite