### PR TITLE
Merge the fs_error branch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,7 +18,6 @@
 - Add per-rule hit counters state report to improve observability.
 - Add per-attribute cache hit and lookup counters to improve observability.
 - Split CLI state and metrics reports
-- fapolicyd:  Handle FAN_FS_ERROR health events
 
 1.4.5
 - Inform the admin symlinks were skipped when adding paths

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,23 @@ if test $perm = "no"; then
 fi
 AC_CHECK_DECLS([FAN_MARK_FILESYSTEM], [], [], [[#include <linux/fanotify.h>]])
 
+AC_ARG_ENABLE(fanotify-fs-error,
+AS_HELP_STRING([--disable-fanotify-fs-error],
+[disable FAN_FS_ERROR health monitoring even when supported]),
+[enable_fanotify_fs_error=$enableval],
+[enable_fanotify_fs_error=yes])
+case x$enable_fanotify_fs_error in
+	xyes)
+		AC_DEFINE([FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR], [1],
+			[Define to enable FAN_FS_ERROR health monitoring])
+		;;
+	xno)
+		;;
+	*)
+		AC_MSG_ERROR([bad value $enableval for --enable-fanotify-fs-error])
+		;;
+esac
+
 withval=""
 AC_ARG_WITH(rpm,
 AS_HELP_STRING([--with-rpm],[Use the rpm database as a trust source]),
@@ -238,5 +255,6 @@ echo "
 `echo $LDFLAGS | fmt -w 50 | sed 's,^,                          ,'`
   __attr_access support:  $ACCESS
   __attr_dealloc_free support: $DEALLOC
+  FAN_FS_ERROR monitoring: $enable_fanotify_fs_error
 "
  

--- a/configure.ac
+++ b/configure.ac
@@ -151,22 +151,25 @@ if test $perm = "no"; then
 fi
 AC_CHECK_DECLS([FAN_MARK_FILESYSTEM], [], [], [[#include <linux/fanotify.h>]])
 
-AC_ARG_ENABLE(fanotify-fs-error,
-AS_HELP_STRING([--disable-fanotify-fs-error],
-[disable FAN_FS_ERROR health monitoring even when supported]),
-[enable_fanotify_fs_error=$enableval],
-[enable_fanotify_fs_error=yes])
-case x$enable_fanotify_fs_error in
-	xyes)
-		AC_DEFINE([FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR], [1],
-			[Define to enable FAN_FS_ERROR health monitoring])
-		;;
-	xno)
-		;;
-	*)
-		AC_MSG_ERROR([bad value $enableval for --enable-fanotify-fs-error])
-		;;
-esac
+enable_fanotify_fs_error=no
+dnl FAN_FS_ERROR shutdown currently exposes a kernel close(2) hang. Keep the
+dnl monitor compiled out until the kernel problem is understood.
+dnl AC_ARG_ENABLE(fanotify-fs-error,
+dnl AS_HELP_STRING([--disable-fanotify-fs-error],
+dnl [disable FAN_FS_ERROR health monitoring even when supported]),
+dnl [enable_fanotify_fs_error=$enableval],
+dnl [enable_fanotify_fs_error=yes])
+dnl case x$enable_fanotify_fs_error in
+dnl 	xyes)
+dnl 		AC_DEFINE([FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR], [1],
+dnl 			[Define to enable FAN_FS_ERROR health monitoring])
+dnl 		;;
+dnl 	xno)
+dnl 		;;
+dnl 	*)
+dnl 		AC_MSG_ERROR([bad value $enableval for --enable-fanotify-fs-error])
+dnl 		;;
+dnl esac
 
 withval=""
 AC_ARG_WITH(rpm,

--- a/src/daemon/fanotify-fs-error.c
+++ b/src/daemon/fanotify-fs-error.c
@@ -606,7 +606,7 @@ int fanotify_fs_error_init(mlist *m)
 	    "the required fanotify info records");
 #else
 	msg(LOG_INFO,
-	    "FAN_FS_ERROR monitoring disabled by configure option");
+	    "FAN_FS_ERROR monitoring disabled");
 #endif
 	return -1;
 }

--- a/src/daemon/fanotify-fs-error.c
+++ b/src/daemon/fanotify-fs-error.c
@@ -36,9 +36,9 @@
  * queue handled by notify.c.
  *
  * Header and kernel support vary across supported build targets. Public entry
- * points stay available even when FAN_FS_ERROR symbols are absent; in that case
- * initialization reports that monitoring is unavailable and all other helpers
- * become harmless no-ops.
+ * points stay available even when FAN_FS_ERROR symbols are absent or configure
+ * disables this monitor; in that case initialization reports that monitoring is
+ * unavailable and all other helpers become harmless no-ops.
  */
 
 #include "config.h" /* Needed to get O_LARGEFILE definition */
@@ -62,7 +62,8 @@
 #define FANOTIFY_FS_ERROR_BUFFER_SIZE 8192
 #define FS_ERROR_LOG_INTERVAL 60
 
-#if defined(FAN_FS_ERROR) && defined(FAN_REPORT_FID) && \
+#if defined(FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR) && \
+	defined(FAN_FS_ERROR) && defined(FAN_REPORT_FID) && \
 	defined(FAN_MARK_FILESYSTEM) && \
 	defined(FAN_EVENT_INFO_TYPE_ERROR) && \
 	defined(FAN_EVENT_INFO_TYPE_FID)
@@ -599,9 +600,14 @@ void fanotify_fs_error_unmark(const char *path)
 int fanotify_fs_error_init(mlist *m)
 {
 	(void)m;
+#if defined(FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR)
 	msg(LOG_INFO,
 	    "FAN_FS_ERROR monitoring disabled; kernel headers do not provide "
 	    "the required fanotify info records");
+#else
+	msg(LOG_INFO,
+	    "FAN_FS_ERROR monitoring disabled by configure option");
+#endif
 	return -1;
 }
 #endif

--- a/src/daemon/fapolicyd.c
+++ b/src/daemon/fapolicyd.c
@@ -1322,11 +1322,13 @@ int main(int argc, const char *argv[])
 	handle_mounts(pfd[0].fd);
 	pfd[1].fd = init_fanotify(&config, m);
 	pfd[1].events = POLLIN;
+#ifdef FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR
 	pfd[2].fd = fanotify_fs_error_fd();
 	if (pfd[2].fd >= 0) {
 		pfd[2].events = POLLIN;
 		pfd_count = 3;
 	}
+#endif
 
 	msg(LOG_INFO, "Starting to listen for events");
 	while (!stop) {

--- a/src/tests/notify_test.c
+++ b/src/tests/notify_test.c
@@ -1,6 +1,7 @@
 /*
  * notify_test.c - unit tests for daemon fanotify metadata handling
  */
+#include "config.h"
 #include <error.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -23,7 +24,8 @@
 #define FAN_Q_OVERFLOW		0x00004000
 #endif
 
-#if defined(FAN_FS_ERROR) && defined(FAN_REPORT_FID) && \
+#if defined(FAPOLICYD_ENABLE_FANOTIFY_FS_ERROR) && \
+	defined(FAN_FS_ERROR) && defined(FAN_REPORT_FID) && \
 	defined(FAN_MARK_FILESYSTEM) && \
 	defined(FAN_EVENT_INFO_TYPE_ERROR) && \
 	defined(FAN_EVENT_INFO_TYPE_FID)


### PR DESCRIPTION
The fs_error branch contains work to isolate and disable the FAN_FS_ERROR monitoring. The configure switch is commented out to reduce chances of it being enabled. The the work remains preserved for future use.