### PR TITLE
Fix DATA_FORMAT printf/scanf for 32-bit architectures with 64-bit off_t

### DIFF
--- a/src/cli/fapolicyd-cli.c
+++ b/src/cli/fapolicyd-cli.c
@@ -249,7 +249,7 @@ static int do_dump_db(void)
 	do {
 		char *path = NULL, *data = NULL, sha[FILE_DIGEST_STRING_MAX];
 		unsigned int tsource;
-		size_t size;
+		unsigned long long ull_size;
 		const char *source;
 
 		path = malloc(key.mv_size + 1);
@@ -266,11 +266,11 @@ static int do_dump_db(void)
 		memcpy(data, val.mv_data, val.mv_size);
 		data[val.mv_size] = 0;
 
-		if (sscanf(data, DATA_FORMAT_IN, &tsource, &size, sha) != 3)
+		if (sscanf(data, DATA_FORMAT_IN, &tsource, &ull_size, sha) != 3)
 			goto next_record;
 
 		source = lookup_tsource(tsource);
-		printf("%s %s %zu %s\n", source, path, size, sha);
+		printf("%s %s %llu %s\n", source, path, ull_size, sha);
 
 next_record:
 		free(data);
@@ -826,6 +826,7 @@ static int check_trustdb(void)
 	do {
 		unsigned int tsource;
 		off_t size;
+		unsigned long long ull_size;
 		char sha[FILE_DIGEST_STRING_MAX];
 		char path[448];
 		char data[TRUSTDB_DATA_BUFSZ];
@@ -836,10 +837,11 @@ static int check_trustdb(void)
 			(char *) entry->path.mv_data);
 		snprintf(data, sizeof(data), "%.*s", (int) entry->data.mv_size,
 			(char *) entry->data.mv_data);
-		if (sscanf(data, DATA_FORMAT_IN, &tsource, &size, sha) != 3) {
+		if (sscanf(data, DATA_FORMAT_IN, &tsource, &ull_size, sha) != 3) {
 			fprintf(stderr, "%s data entry is corrupted\n", path);
 			continue;
 		}
+		size = (off_t)ull_size;
 		if (verify_file(path, size, sha, tsource))
 			found = 1;
 	} while (walk_database_next());

--- a/src/library/database.c
+++ b/src/library/database.c
@@ -3250,13 +3250,13 @@ static int handle_record(const char * buffer)
 {
 	char path[2048+1];
 	char hash[64+1];
-	size_t size;
+	unsigned long long ull_size;
 
 	if (stop)
 		return 1;
 
 	// validating input
-	int res = sscanf(buffer, "%2048s %zu %64s", path, &size, hash);
+	int res = sscanf(buffer, "%2048s %llu %64s", path, &ull_size, hash);
 	msg(LOG_DEBUG, "update_thread: Parsing input buffer: %s", buffer);
 	msg(LOG_DEBUG,
 	    "update_thread: Parsing input words(expected 3): %d",
@@ -3269,7 +3269,7 @@ static int handle_record(const char * buffer)
 
 	char data[BUFFER_SIZE];
 	snprintf(data, BUFFER_SIZE, DATA_FORMAT, (unsigned int)SRC_UNKNOWN,
-		 size, hash);
+		 ull_size, hash);
 
 	msg(LOG_DEBUG, "update_thread: Saving %s %s", path, data);
 	lock_update_thread();

--- a/src/library/fapolicyd-backend.h
+++ b/src/library/fapolicyd-backend.h
@@ -38,8 +38,8 @@ typedef enum { SRC_UNKNOWN, SRC_RPM, SRC_FILE_DB, SRC_DEB } trust_src_t;
 // bytes to write.  helper: stringify macro value
 #define STR_IMPL(x) #x
 #define STR(x) STR_IMPL(x)
-#define DATA_FORMAT "%u %zu %s"
-#define DATA_FORMAT_IN "%u %zu %" STR(FILE_DIGEST_STRING_WIDTH) "s"
+#define DATA_FORMAT "%u %llu %s"
+#define DATA_FORMAT_IN "%u %llu %" STR(FILE_DIGEST_STRING_WIDTH) "s"
 
 typedef struct _backend
 {

--- a/src/library/md5-backend.c
+++ b/src/library/md5-backend.c
@@ -120,7 +120,8 @@ int add_file_to_backend_by_md5(const char *path, const char *expected_md5,
 	}
 
 	char *data;
-	if (asprintf(&data, DATA_FORMAT, trust_src, file_size, sha_digest) == -1) {
+	if (asprintf(&data, DATA_FORMAT, trust_src,
+		     (unsigned long long)file_size, sha_digest) == -1) {
 		data = NULL;
 	}
 	free(sha_digest);
@@ -153,4 +154,3 @@ int add_file_to_backend_by_md5(const char *path, const char *expected_md5,
 	}
 	return 1;
 }
-

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -391,7 +391,7 @@ int do_rpm_load_list(const conf_t *conf, int memfd)
 			if (asprintf(	&data,
 					DATA_FORMAT,
 					tsource,
-					sz,
+					(unsigned long long)sz,
 					sha) == -1) {
 				data = NULL;
 			}

--- a/src/library/trust-file.c
+++ b/src/library/trust-file.c
@@ -128,7 +128,7 @@ static char *make_data_string(const char *path)
 	 * path is stored as lmdb index
 	 */
 	int count = asprintf(&line, DATA_FORMAT, 0,
-					  sb.st_size, hash);
+					  (unsigned long long)sb.st_size, hash);
 
 	free(hash);
 
@@ -370,7 +370,8 @@ int trust_file_load(const char *fpath, list_t *list, int memfd)
 		}
 
 		int len = snprintf(data_buf, sizeof(data_buf),
-				   DATA_FORMAT, tsource, sz, sha);
+				   DATA_FORMAT, tsource,
+				   (unsigned long long)sz, sha);
 		if (len < 0 || len >= (int)sizeof(data_buf)) {
 			msg(LOG_ERR, "Entry too large in %s", fpath);
 			continue;

--- a/src/tests/event_test.c
+++ b/src/tests/event_test.c
@@ -593,10 +593,12 @@ struct lmdb_record {
 static int parse_record(const char *record, struct lmdb_record *parsed)
 {
 	size_t expected_len;
+	unsigned long long ull_size;
 
-	if (sscanf(record, DATA_FORMAT_IN, &parsed->tsource, &parsed->size,
+	if (sscanf(record, DATA_FORMAT_IN, &parsed->tsource, &ull_size,
 		parsed->digest) != 3)
 		return 1;
+	parsed->size = (off_t)ull_size;
 
 	parsed->digest_len = strlen(parsed->digest);
 	parsed->alg = file_hash_alg(parsed->digest_len);
@@ -620,7 +622,7 @@ static int test_rpm_accepts_sha512(void)
 		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
 	snprintf(record, sizeof(record), DATA_FORMAT, (unsigned int)SRC_RPM,
-		 (size_t)8192, sha512);
+		 8192ULL, sha512);
 	CHECK(parse_record(record, &parsed) == 0, 40,
 	      "[ERROR:40] parse failed for RPM SHA512 digest");
 	CHECK(parsed.alg == FILE_HASH_ALG_SHA512, 41,
@@ -639,7 +641,7 @@ static int test_filedb_rejects_sha512(void)
 		"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 
 	snprintf(record, sizeof(record), DATA_FORMAT, (unsigned int)SRC_FILE_DB,
-		 (size_t)4096, sha512);
+		 4096ULL, sha512);
 	CHECK(parse_record(record, &parsed) != 0, 50,
 	      "[ERROR:50] filedb SHA512 digest unexpectedly accepted");
 	return 0;
@@ -653,7 +655,7 @@ static int test_filedb_accepts_sha256(void)
 		"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
 	snprintf(record, sizeof(record), DATA_FORMAT, (unsigned int)SRC_FILE_DB,
-		 (size_t)1024, sha256);
+		 1024ULL, sha256);
 	CHECK(parse_record(record, &parsed) == 0, 60,
 	      "[ERROR:60] filedb SHA256 digest rejected");
 	CHECK(parsed.alg == FILE_HASH_ALG_SHA256, 61,

--- a/src/tests/trustdb_format_test.c
+++ b/src/tests/trustdb_format_test.c
@@ -3,7 +3,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <sys/types.h>
 #include "fapolicyd-backend.h"
 
 int main(void)
@@ -13,15 +12,15 @@ int main(void)
 	char data[TRUSTDB_DATA_BUFSZ];
 	char parsed_digest[FILE_DIGEST_STRING_MAX];
 	unsigned int tsource;
-	off_t size;
+	unsigned long long ull_size;
 	int written;
 
-	written = snprintf(data, sizeof(data), DATA_FORMAT, SRC_RPM, (off_t)9400,
-			 digest);
+	written = snprintf(data, sizeof(data), DATA_FORMAT, SRC_RPM,
+			   9400ULL, digest);
 	if (written < 0 || written >= (int)sizeof(data))
 		return 1;
 
-	if (sscanf(data, DATA_FORMAT_IN, &tsource, &size, parsed_digest) != 3)
+	if (sscanf(data, DATA_FORMAT_IN, &tsource, &ull_size, parsed_digest) != 3)
 		return 1;
 
 	if (strcmp(digest, parsed_digest))

--- a/src/tests/trustdb_lmdb_test.c
+++ b/src/tests/trustdb_lmdb_test.c
@@ -192,15 +192,15 @@ static int test_data_format_round_trip(void)
 	char data[TRUSTDB_DATA_BUFSZ];
 	char parsed_digest[FILE_DIGEST_STRING_MAX];
 	unsigned int tsource;
-	off_t size;
+	unsigned long long ull_size;
 	int written;
 
 	written = snprintf(data, sizeof(data), DATA_FORMAT, SRC_RPM,
-			   (off_t)9400, digest);
+			   9400ULL, digest);
 	CHECK(written >= 0 && written < (int)sizeof(data), 10,
 	      "[ERROR:10] DATA_FORMAT output truncated");
 
-	CHECK(sscanf(data, DATA_FORMAT_IN, &tsource, &size, parsed_digest) == 3,
+	CHECK(sscanf(data, DATA_FORMAT_IN, &tsource, &ull_size, parsed_digest) == 3,
 	      11, "[ERROR:11] DATA_FORMAT_IN parse failed");
 	CHECK(strcmp(digest, parsed_digest) == 0, 12,
 	      "[ERROR:12] digest mismatch after round trip");
@@ -222,7 +222,7 @@ static int test_lmdb_short_path_round_trip(void)
 	CHECK(rc == 0, 20, "[ERROR:20] failed to open temporary LMDB");
 
 	snprintf(payload, sizeof(payload), "%s " DATA_FORMAT "\n", path,
-		 SRC_FILE_DB, (size_t)1234, digest);
+		 SRC_FILE_DB, 1234ULL, digest);
 	rc = import_records(payload, &entries);
 	CHECK(rc == 0 && entries == 1, 21,
 	      "[ERROR:21] short-path record import failed");
@@ -254,7 +254,7 @@ static int test_lmdb_long_path_round_trip(void)
 	CHECK(rc == 0, 31, "[ERROR:31] failed to open temporary LMDB");
 
 	snprintf(payload, sizeof(payload), "%s " DATA_FORMAT "\n", path,
-		 SRC_FILE_DB, (size_t)2048, digest);
+		 SRC_FILE_DB, 2048ULL, digest);
 	rc = import_records(payload, &entries);
 	CHECK(rc == 0 && entries == 1, 32,
 	      "[ERROR:32] long-path record import failed");
@@ -300,8 +300,8 @@ static int test_lmdb_long_path_shared_prefix_no_collision(void)
 	 */
 	snprintf(payload, sizeof(payload), "%s " DATA_FORMAT "\n"
 		 "%s " DATA_FORMAT "\n",
-		 path_a, SRC_FILE_DB, (size_t)3000, digest_a,
-		 path_b, SRC_FILE_DB, (size_t)3001, digest_b);
+		 path_a, SRC_FILE_DB, 3000ULL, digest_a,
+		 path_b, SRC_FILE_DB, 3001ULL, digest_b);
 	rc = import_records(payload, &entries);
 	CHECK(rc == 0 && entries == 2, 42,
 	      "[ERROR:42] shared-prefix record import failed");
@@ -354,7 +354,7 @@ static int test_lmdb_readonly_probe_does_not_break_live_env(void)
 	CHECK(rc == 0, 60, "[ERROR:60] failed to open temporary LMDB");
 
 	snprintf(payload, sizeof(payload), "%s " DATA_FORMAT "\n",
-		 "/usr/bin/probe-a", SRC_FILE_DB, (size_t)123, digest_a);
+		 "/usr/bin/probe-a", SRC_FILE_DB, 123ULL, digest_a);
 	rc = import_records(payload, &entries);
 	CHECK(rc == 0 && entries == 1, 61,
 	      "[ERROR:61] initial record import failed");
@@ -370,7 +370,7 @@ static int test_lmdb_readonly_probe_does_not_break_live_env(void)
 
 	entries = 0;
 	snprintf(payload, sizeof(payload), "%s " DATA_FORMAT "\n",
-		 "/usr/bin/probe-b", SRC_FILE_DB, (size_t)456, digest_b);
+		 "/usr/bin/probe-b", SRC_FILE_DB, 456ULL, digest_b);
 	rc = import_records(payload, &entries);
 	CHECK(rc == 0 && entries == 1, 65,
 	      "[ERROR:65] live environment import failed after probe close");
@@ -407,10 +407,11 @@ static int test_lmdb_chunked_import(void)
 	CHECK(stream != NULL, 91,
 	      "[ERROR:91] failed to allocate chunked payload");
 
-	for (unsigned int i = 0; i < record_count; i++) {
-		fprintf(stream, "/usr/bin/chunked-%04u " DATA_FORMAT "\n",
-			i, SRC_FILE_DB, (size_t)(9000 + i), digest);
-	}
+		for (unsigned int i = 0; i < record_count; i++) {
+			fprintf(stream, "/usr/bin/chunked-%04u " DATA_FORMAT "\n",
+				i, SRC_FILE_DB,
+				(unsigned long long)(9000 + i), digest);
+		}
 	fclose(stream);
 
 	rc = import_records(payload, &entries);
@@ -452,7 +453,7 @@ static int test_lmdb_long_path_negative_lookup(void)
 	CHECK(rc == 0, 51, "[ERROR:51] failed to open temporary LMDB");
 
 	snprintf(payload, sizeof(payload), "%s " DATA_FORMAT "\n", path_a,
-		 SRC_FILE_DB, (size_t)4100, digest);
+		 SRC_FILE_DB, 4100ULL, digest);
 	rc = import_records(payload, &entries);
 	CHECK(rc == 0 && entries == 1, 52,
 	      "[ERROR:52] negative-lookup record import failed");
@@ -497,7 +498,7 @@ static int test_lmdb_concurrent_read_handles(void)
 	CHECK(rc == 0, 70, "[ERROR:70] failed to open temporary LMDB");
 
 	snprintf(payload, sizeof(payload), "%s " DATA_FORMAT "\n", path,
-		 SRC_FILE_DB, (size_t)555, digest);
+		 SRC_FILE_DB, 555ULL, digest);
 	rc = import_records(payload, &entries);
 	CHECK(rc == 0 && entries == 1, 71,
 	      "[ERROR:71] concurrent record import failed");


### PR DESCRIPTION
On 32-bit architectures where _FILE_OFFSET_BITS=64 is defined (e.g. by a distribution's build system), off_t is 64-bit while size_t remains 32-bit. The trust database format macros DATA_FORMAT and DATA_FORMAT_IN used %zu, which expects a size_t-sized argument. Passing off_t values with %zu causes two distinct problems:  

* printf/snprintf: a 64-bit off_t argument misaligns the variadic argument stack on 32-bit ARM, causing the subsequent %s to be read from the wrong location and producing corrupt output.
* scanf/sscanf: %zu writes only 4 bytes into an 8-byte off_t, leaving the upper half corrupted, which can cause file size comparisons to fail.

This fix changes DATA_FORMAT and DATA_FORMAT_IN to use %llu, and updates all call sites to cast file size values to unsigned long long for printf-family calls and to use an intermediate unsigned long long ull_size variable for scanf-family calls before assigning back to off_t.  

This issue was originally identified as a build failure (FTBFS) on armhf in Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1132273. The root cause is that Debian injects -D_FILE_OFFSET_BITS=64 via dpkg-buildflags for all packages on 32-bit architectures. Any other distribution or build environment that defines _FILE_OFFSET_BITS=64 on a 32-bit target will encounter the same issue, so this fix is beneficial beyond Debian.