### PR TITLE
doc: fix groff warnings in man pages

### DIFF
--- a/doc/fapolicyd.conf.5
+++ b/doc/fapolicyd.conf.5
@@ -212,9 +212,7 @@ Ensure each mount is truly \fIdata\-only\fR and is mounted with \fBnoexec\fR.
 .IP \[bu]
 Run the advisory check:
 .nf
-\f[C]
-fapolicyd-cli --check-ignore_mounts[=MOUNT]
-\f[R]
+.B fapolicyd-cli --check-ignore_mounts[=MOUNT]
 .fi
 to verify the mount exists, confirm \fBnoexec\fR, and scan for files matching the \fB%languages\fR macro. The command reports findings and returns a non\-zero status when potentially executable content is detected.
 .IP \[bu]

--- a/doc/fapolicyd.rules.5
+++ b/doc/fapolicyd.rules.5
@@ -151,7 +151,7 @@ Set is a named group of values of the same type. Fapolicyd internally distinguis
 .SS SETS EXAMPLES
 .nf
 .B # definition
-.b # string set
+.B # string set
 .B %python=/usr/bin/python2.7,/usr/bin/python3.6
 .B allow exe=%python : all trust=1
 .B #


### PR DESCRIPTION
Fix two groff formatting errors in the packaged man pages that produce warnings when the pages are processed by troff:

- fapolicyd.rules.5: `.b` is not a valid groff macro, causing a "name 'b' not defined" warning. Replace with `.B` (bold text macro).

- fapolicyd.conf.5: `\f[C]` requests the "C" (constant-width) font which is not available in all groff output devices, causing a "cannot select font 'C'" warning. Replace the font-escape block with the standard `.B` bold macro.

These warnings can be reproduced by running:

    LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
        man --warnings -E UTF-8 -l -Tutf8 -Z <file> >/dev/null