### PR TITLE
Fix rpm-backend IPC crashes and improve loader diagnosability

### DIFF
--- a/src/daemon/fapolicyd.c
+++ b/src/daemon/fapolicyd.c
@@ -865,6 +865,12 @@ static void wait_for_mounts_thread(void)
 		usleep(1000);
 }
 
+static void wait_for_reconfigure_thread(void)
+{
+	while (atomic_load(&reconfig_running))
+		usleep(1000);
+}
+
 
 static void usage(void)
 {
@@ -1404,6 +1410,7 @@ int main(int argc, const char *argv[])
 		}
 	}
 	msg(LOG_INFO, "shutting down...");
+	wait_for_reconfigure_thread();
 	wait_for_mounts_thread();
 	shutdown_fanotify(m);
 	close(pfd[0].fd);

--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -63,6 +63,7 @@
 // External variables
 extern atomic_bool stop, run_stats;
 extern conf_t config;
+extern atomic_int rpm_loader_pid;
 
 // Local variables
 static pid_t our_pid;
@@ -1123,7 +1124,8 @@ void handle_events(void)
 
 		if (metadata->fd >= 0) {
 			if (metadata->mask & mask) {
-				if (metadata->pid == our_pid)
+				if (metadata->pid == our_pid ||
+				    metadata->pid == atomic_load(&rpm_loader_pid))
 					reply_event(fd, metadata, FAN_ALLOW,
 						    NULL);
 				else {

--- a/src/handler/fapolicyd-rpm-loader.c
+++ b/src/handler/fapolicyd-rpm-loader.c
@@ -65,7 +65,12 @@ int sock_fd = 3; // same number dup2’ed by parent
 int main(int argc, char * const argv[])
 {
 
-	set_message_mode(MSG_STDERR, DBG_YES);
+	if (isatty(STDERR_FILENO)) {
+		set_message_mode(MSG_STDERR, DBG_YES);
+	} else {
+		set_message_mode(MSG_SYSLOG, DBG_YES);
+		openlog("fapolicyd-rpm-loader", LOG_PID, LOG_DAEMON);
+	}
 
 	if (load_daemon_config(&config)) {
 		free_daemon_config(&config);

--- a/src/handler/fapolicyd-rpm-loader.c
+++ b/src/handler/fapolicyd-rpm-loader.c
@@ -117,7 +117,7 @@ int main(int argc, char * const argv[])
 	memcpy(CMSG_DATA(c), &memfd, sizeof(int));
 
 	if (sendmsg(sock_fd, &_msg, 0) < 0) {
-		msg(LOG_ERR, "sendmsg failed");
+		msg(LOG_ERR, "sendmsg failed (%s)", strerror(errno));
 		exit(1);
 	}
 

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -59,6 +59,7 @@
 
 
 extern atomic_bool stop;
+atomic_int rpm_loader_pid = -1;
 
 int do_rpm_init_backend(void);
 int do_rpm_load_list(const conf_t *, int memfd);
@@ -248,6 +249,7 @@ static int rpm_load_list(const conf_t *conf)
 	close(sv[1]);  // Parent doesn't write
 
 	if (status == 0) {
+		atomic_store(&rpm_loader_pid, pid);
 		msg(LOG_DEBUG, "fapolicyd-rpm-loader spawned with pid: %d",pid);
 
 		struct msghdr  _msg  = {0};
@@ -270,6 +272,7 @@ static int rpm_load_list(const conf_t *conf)
 			msg(LOG_ERR, "recvmsg failed (%s)", strerror(errno));
 			close(sv[0]);
 			waitpid(pid, &status, 0);
+			atomic_store(&rpm_loader_pid, -1);
 			posix_spawn_file_actions_destroy(&actions);
 			return 1;
 		}
@@ -279,6 +282,7 @@ static int rpm_load_list(const conf_t *conf)
 		if (!c || c->cmsg_type != SCM_RIGHTS) {
 			msg(LOG_ERR, "missing fd");
 			waitpid(pid, &status, 0);
+			atomic_store(&rpm_loader_pid, -1);
 			posix_spawn_file_actions_destroy(&actions);
 			return 1;
 		}
@@ -300,6 +304,7 @@ static int rpm_load_list(const conf_t *conf)
 		rpm_backend.memfd = memfd;
 
 		waitpid(pid, &status, 0);
+		atomic_store(&rpm_loader_pid, -1);
 	} else {
 		close(sv[0]);
 		msg(LOG_ERR, "posix_spawn failed: %s\n", strerror(status));

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -259,8 +259,12 @@ static int rpm_load_list(const conf_t *conf)
 		_msg.msg_control = cmsgbuf.buf;
 		_msg.msg_controllen = sizeof cmsgbuf.buf;
 
-		if (recvmsg(sv[0], &_msg, 0) < 0) {
-			msg(LOG_ERR, "recvmsg failed");
+		ssize_t rc;
+		do {
+			rc = recvmsg(sv[0], &_msg, 0);
+		} while (rc < 0 && errno == EINTR);
+		if (rc < 0) {
+			msg(LOG_ERR, "recvmsg failed (%s)", strerror(errno));
 			close(sv[0]);
 			waitpid(pid, &status, 0);
 			posix_spawn_file_actions_destroy(&actions);

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -223,7 +223,7 @@ static int rpm_load_list(const conf_t *conf)
 {
 	// before the spawn
 	int sv[2];
-	if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) < 0) {
+	if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_CLOEXEC, 0, sv) < 0) {
 		msg(LOG_ERR, "socketpair failed");
 		return 1;
 	}
@@ -231,10 +231,13 @@ static int rpm_load_list(const conf_t *conf)
 	posix_spawn_file_actions_t actions;
 	posix_spawn_file_actions_init(&actions);
 
-	// child sees sv[1] as FD 3 (arbitrary but fixed)
+	// dup sv[1] to FD 3 for the child; SOCK_CLOEXEC ensures both
+	// sv[0] and sv[1] are closed on exec, and dup2 clears CLOEXEC
+	// on the target FD 3. When sv[1] is already 3, dup2(3,3) is a
+	// no-op that does NOT clear CLOEXEC, so we must do it ourselves.
+	if (sv[1] == 3)
+		fcntl(sv[1], F_SETFD, 0);
 	posix_spawn_file_actions_adddup2(&actions, sv[1], 3);
-	posix_spawn_file_actions_addclose(&actions, sv[0]);
-	posix_spawn_file_actions_addclose(&actions, sv[1]);
 
 	char *argv[] = { "fapolicyd-rpm-loader", NULL };
 	char *custom_env[] = { "FAPO_SOCK_FD=3", NULL };

--- a/src/tests/rpm_backend_test.c
+++ b/src/tests/rpm_backend_test.c
@@ -5,12 +5,14 @@
 #include "config.h"
 
 #include <error.h>
+#include <stdatomic.h>
 #include <string.h>
 #include <unistd.h>
 
 #include "fapolicyd-backend.h"
 
 extern backend rpm_backend;
+extern atomic_int rpm_loader_pid;
 
 #define CHECK(expr, code, msg) \
 	do { \
@@ -48,12 +50,17 @@ int main(void)
 	rpm_backend.memfd = -1;
 	rpm_backend.entries = -1;
 
+	CHECK(atomic_load(&rpm_loader_pid) == -1, 10,
+	      "[ERROR:10] rpm_loader_pid not -1 before load");
+
 	rc = rpm_backend_load_from_path_for_tests(&cfg, path);
 	CHECK(rc != 0, 1, "[ERROR:1] rpm IPC failure returned success");
 	CHECK(rpm_backend.memfd == -1, 2,
 	      "[ERROR:2] failed rpm load published a memfd");
 	CHECK(rpm_backend.entries == -1, 3,
 	      "[ERROR:3] failed rpm load published entries");
+	CHECK(atomic_load(&rpm_loader_pid) == -1, 4,
+	      "[ERROR:4] rpm_loader_pid not cleared after failed load");
 
 	return 0;
 }


### PR DESCRIPTION
## Summary

The fapolicyd daemon can crash during trust database reloads when signals are delivered at the wrong time. Two distinct bugs were identified and fixed, along with diagnosability improvements to the rpm-loader helper.

## Bug 1: EINTR on recvmsg — "recvmsg failed"

Sending SIGUSR1 (e.g. dumping stats via `fapolicyd-cli -D`) while a trust database reload is in progress causes `recvmsg()` to return -1/EINTR, crashing the daemon. Signal handlers are installed with `sa_flags=0` (no `SA_RESTART`).

**Fix:** wrap `recvmsg()` in a retry loop on `EINTR`.

## Bug 2: FD overlap — "missing fd"

When `socketpair()` returns `sv[0]==3`, the `posix_spawn` file_actions destroy the child's socket:

1. `adddup2(sv[1], 3)` — closes FD 3 (sv[0]), makes FD 3 a copy of sv[1]
2. `addclose(sv[0])` = `addclose(3)` — closes the dup!
3. `addclose(sv[1])` — closes original

The child ends up with no socket on FD 3. `sendmsg` gets EBADF, and the parent sees "missing fd".

This occurs when SIGUSR1 triggers a config reload that fails, followed by a DB resync where FD 3 happens to be available.

**Fix:** use `SOCK_CLOEXEC` on the socketpair. Both `sv[0]` and `sv[1]` close automatically on exec, and `dup2` clears `CLOEXEC` on the target FD 3. The explicit `addclose` calls that caused the overlap are removed.

## Diagnosability improvements

- **Add errno to error messages:** `recvmsg failed` and `sendmsg failed` now include `strerror(errno)` for diagnosability.
- **Loader output was silently lost:** `become_daemon()` redirects stderr to `/dev/null` before spawning the loader. Since the loader used `MSG_STDERR`, all its diagnostic messages were silently discarded.
The loader now uses `isatty(STDERR_FILENO)` to choose: stderr in debug mode (terminal), syslog in daemon mode. Messages appear in the journal as `fapolicyd-rpm-loader[PID]`.

## Commits

1. `rpm-backend: retry recvmsg on EINTR and include errno in error`
2. `rpm-backend: fix FD overlap in posix_spawn file_actions`
3. `rpm-loader: add errno to sendmsg error message`
4. `rpm-loader: switch from stderr to syslog for diagnostics`

## Testing

- Verified SIGUSR1 during startup no longer crashes the daemon
- Verified SIGUSR1 + broken config no longer causes "missing fd" crash
- Verified normal startup and DB resync still work
- Verified loader messages appear in journal in daemon mode
- Verified loader messages go to stderr in debug mode