### PR TITLE
rpm-loader: add missing errno to recvmsg/sendmsg + switch to syslog

### DIFF
--- a/src/handler/fapolicyd-rpm-loader.c
+++ b/src/handler/fapolicyd-rpm-loader.c
@@ -65,7 +65,8 @@ int sock_fd = 3; // same number dup2’ed by parent
 int main(int argc, char * const argv[])
 {
 
-	set_message_mode(MSG_STDERR, DBG_YES);
+	set_message_mode(MSG_SYSLOG, DBG_NO);
+	openlog("fapolicyd-rpm-loader", LOG_PID, LOG_DAEMON);
 
 	if (load_daemon_config(&config)) {
 		free_daemon_config(&config);
@@ -117,7 +118,9 @@ int main(int argc, char * const argv[])
 	memcpy(CMSG_DATA(c), &memfd, sizeof(int));
 
 	if (sendmsg(sock_fd, &_msg, 0) < 0) {
-		msg(LOG_ERR, "sendmsg failed");
+		char err_buff[256];
+		msg(LOG_ERR, "sendmsg failed (%s)",
+		    strerror_r(errno, err_buff, sizeof(err_buff)));
 		exit(1);
 	}
 

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -278,7 +278,9 @@ static int rpm_load_list(const conf_t *conf)
 			rc = recvmsg(sv[0], &_msg, 0);
 		} while (rc < 0 && errno == EINTR);
 		if (rc < 0) {
-			msg(LOG_ERR, "recvmsg failed");
+			char err_buff[BUFFER_SIZE];
+			msg(LOG_ERR, "recvmsg failed (%s)",
+			    strerror_r(errno, err_buff, BUFFER_SIZE));
 			close(sv[0]);
 			while (waitpid(pid, &status, 0) < 0 && errno == EINTR);
 			posix_spawn_file_actions_destroy(&actions);


### PR DESCRIPTION
Errors were missing details, making it difficult to diagnose:

the daemon's `become_daemon()` redirects `stderr` to `/dev/null` before spawning the loader. Since the loader used `MSG_STDERR`, all its diagnostic messages (config errors, RPM load failures, sendmsg errors) were silently lost, making failures impossible to diagnose.

Now use `MSG_SYSLOG` so messages appear in the journal as `fapolicyd-rpm-loader[PID]`.