### PR TITLE
rpm-backend: fix FD overlap in posix_spawn file_actions

### DIFF
--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -223,7 +223,7 @@ static int rpm_load_list(const conf_t *conf)
 {
 	// before the spawn
 	int sv[2];
-	if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv) < 0) {
+	if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_CLOEXEC, 0, sv) < 0) {
 		msg(LOG_ERR, "socketpair failed");
 		return 1;
 	}
@@ -231,10 +231,24 @@ static int rpm_load_list(const conf_t *conf)
 	posix_spawn_file_actions_t actions;
 	posix_spawn_file_actions_init(&actions);
 
-	// child sees sv[1] as FD 3 (arbitrary but fixed)
+	// dup sv[1] to FD 3 for the child; SOCK_CLOEXEC ensures both
+	// sv[0] and sv[1] are closed on exec, and dup2 clears CLOEXEC
+	// on the target FD 3. When sv[1] is already 3, dup2(3,3) is a
+	// no-op that does NOT clear CLOEXEC, so move sv[1] to a
+	// different FD to avoid the overlap.
+	if (sv[1] == 3) {
+		int tmp = fcntl(sv[1], F_DUPFD_CLOEXEC, 4);
+		if (tmp < 0) {
+			msg(LOG_ERR, "fcntl F_DUPFD_CLOEXEC failed");
+			close(sv[0]);
+			close(sv[1]);
+			posix_spawn_file_actions_destroy(&actions);
+			return 1;
+		}
+		close(sv[1]);
+		sv[1] = tmp;
+	}
 	posix_spawn_file_actions_adddup2(&actions, sv[1], 3);
-	posix_spawn_file_actions_addclose(&actions, sv[0]);
-	posix_spawn_file_actions_addclose(&actions, sv[1]);
 
 	char *argv[] = { "fapolicyd-rpm-loader", NULL };
 	char *custom_env[] = { "FAPO_SOCK_FD=3", NULL };


### PR DESCRIPTION
When socketpair() returns `sv[0]==3`, the posix_spawn file_actions destroy the child's socket:
  1. `adddup2(sv[1], 3)` - closes FD 3 (`sv[0]`), makes FD 3 a copy of `sv[1]`
  2. `addclose(sv[0]) = addclose(3)` - closes the dup!
  3. `addclose(sv[1])` - closes original The child ends up with no socket on FD 3, sendmsg gets EBADF, and the parent sees "missing fd".

This occurs when `SIGHUP` triggers a config reload that fails, followed by a DB resync where FD 3 happens to be available.

Reproducer: add a broken line to `fapolicyd.conf`, then send `SIGHUP`. Output before fix:
~~~
fapolicyd[2502]: Wrong number of arguments for line 24 in /etc/fapolicyd/fapolicyd.conf
fapolicyd[2502]: Not processing any more lines in /etc/fapolicyd/fapolicyd.conf
fapolicyd[2502]: Failed reloading daemon configuration
fapolicyd[2502]: Continuing with previous configuration settings
fapolicyd[2502]: Ruleset identity: d911b3a1...
fapolicyd[2502]: It looks like there was an update of the system... Syncing DB.
fapolicyd[2502]: missing fd
systemd[1]: fapolicyd.service: Main process exited, code=exited, status=1/FAILURE
~~~

Fix: use `SOCK_CLOEXEC` on the socketpair so both `sv[0]` and `sv[1]` close automatically on exec. Only `adddup2(sv[1], 3)` is needed since dup2 clears `CLOEXEC` on the target FD. The explicit addclose calls that caused the overlap are no longer needed.