### PR TITLE
systemd: restart fapolicyd on failure

### DIFF
--- a/init/fapolicyd.service
+++ b/init/fapolicyd.service
@@ -17,7 +17,8 @@ RuntimeDirectory=fapolicyd
 PIDFile=/run/fapolicyd.pid
 ExecStartPre=/usr/sbin/fagenrules
 ExecStart=/usr/sbin/fapolicyd
-Restart=on-abnormal
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Before the fix fapolicyd was only restarting `on-abnormal`, which means if a signal or crash occurred.
This isn't sufficient since failure due to PR https://github.com/linux-application-whitelisting/fapolicyd/pull/419 or https://github.com/linux-application-whitelisting/fapolicyd/pull/421 were not caught.