### PR TITLE
rpm-backend: auto-allow loader child in fanotify

### DIFF
--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -84,6 +84,9 @@
 // External variables
 extern atomic_bool stop, run_stats;
 extern conf_t config;
+#ifdef USE_RPM
+extern atomic_int rpm_loader_pid;
+#endif
 
 // Local variables
 static pid_t our_pid;
@@ -542,7 +545,11 @@ void handle_events(void)
 
 		if (metadata->fd >= 0) {
 			if (metadata->mask & mask) {
-				if (metadata->pid == our_pid)
+				if (metadata->pid == our_pid
+#ifdef USE_RPM
+				    || metadata->pid == atomic_load(&rpm_loader_pid)
+#endif
+				)
 					reply_event(fd, metadata, FAN_ALLOW,
 						    NULL);
 				else {

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -59,6 +59,7 @@
 
 
 extern atomic_bool stop;
+atomic_int rpm_loader_pid = -1;
 
 int do_rpm_init_backend(void);
 int do_rpm_load_list(const conf_t *, int memfd);
@@ -245,6 +246,7 @@ static int rpm_load_list(const conf_t *conf)
 	close(sv[1]);  // Parent doesn't write
 
 	if (status == 0) {
+		atomic_store(&rpm_loader_pid, pid);
 		msg(LOG_DEBUG, "fapolicyd-rpm-loader spawned with pid: %d",pid);
 
 		struct msghdr  _msg  = {0};
@@ -263,6 +265,7 @@ static int rpm_load_list(const conf_t *conf)
 			msg(LOG_ERR, "recvmsg failed");
 			close(sv[0]);
 			waitpid(pid, &status, 0);
+			atomic_store(&rpm_loader_pid, -1);
 			posix_spawn_file_actions_destroy(&actions);
 			return 1;
 		}
@@ -272,6 +275,7 @@ static int rpm_load_list(const conf_t *conf)
 		if (!c || c->cmsg_type != SCM_RIGHTS) {
 			msg(LOG_ERR, "missing fd");
 			waitpid(pid, &status, 0);
+			atomic_store(&rpm_loader_pid, -1);
 			posix_spawn_file_actions_destroy(&actions);
 			return 1;
 		}
@@ -293,6 +297,7 @@ static int rpm_load_list(const conf_t *conf)
 		rpm_backend.memfd = memfd;
 
 		waitpid(pid, &status, 0);
+		atomic_store(&rpm_loader_pid, -1);
 	} else {
 		close(sv[0]);
 		msg(LOG_ERR, "posix_spawn failed: %s\n", strerror(status));

--- a/src/tests/rpm_backend_test.c
+++ b/src/tests/rpm_backend_test.c
@@ -5,12 +5,14 @@
 #include "config.h"
 
 #include <error.h>
+#include <stdatomic.h>
 #include <string.h>
 #include <unistd.h>
 
 #include "fapolicyd-backend.h"
 
 extern backend rpm_backend;
+extern atomic_int rpm_loader_pid;
 
 #define CHECK(expr, code, msg) \
 	do { \
@@ -48,12 +50,17 @@ int main(void)
 	rpm_backend.memfd = -1;
 	rpm_backend.entries = -1;
 
+	CHECK(atomic_load(&rpm_loader_pid) == -1, 10,
+	      "[ERROR:10] rpm_loader_pid not -1 before load");
+
 	rc = rpm_backend_load_from_path_for_tests(&cfg, path);
 	CHECK(rc != 0, 1, "[ERROR:1] rpm IPC failure returned success");
 	CHECK(rpm_backend.memfd == -1, 2,
 	      "[ERROR:2] failed rpm load published a memfd");
 	CHECK(rpm_backend.entries == -1, 3,
 	      "[ERROR:3] failed rpm load published entries");
+	CHECK(atomic_load(&rpm_loader_pid) == -1, 4,
+	      "[ERROR:4] rpm_loader_pid not cleared after failed load");
 
 	return 0;
 }


### PR DESCRIPTION
When fapolicyd triggers a trust database reload (e.g. via fapolicyd-cli --update), the trust DB is rebuilt. During the rebuild, posix_spawn of fapolicyd-rpm-loader may be denied by fapolicyd's own fanotify watcher because the loader binary is not yet present in the new (empty/mid-rebuild) trust DB.

In normal operation this does not happen because the loader is RPM-installed and trusted. The race is exposed by the bz1817413 test which sends --update and kill concurrently, forcing a reload while fanotify is active.

The daemon already auto-allows fanotify events from its own PID (our_pid check in handle_events). Extend this to also allow events from the rpm loader child by tracking its PID in an atomic variable (rpm_loader_pid) that is set after posix_spawn and cleared after waitpid in all code paths. The check in notify.c is guarded by #ifdef USE_RPM for --without-rpm builds.

Test: rpm_backend_test verifies rpm_loader_pid is -1 before and after a failed load (no leaked PID that could auto-allow an unrelated process).