### PR TITLE
Move fapolicyd-rpm-loader to libexec

### DIFF
--- a/fapolicyd.spec
+++ b/fapolicyd.spec
@@ -253,7 +253,7 @@ fi
 %attr(755,root,root) %{_sbindir}/%{name}
 %attr(755,root,root) %{_sbindir}/%{name}-cli
 %attr(755,root,root) %{_sbindir}/%{name}-perf-test
-%attr(755,root,root) %{_bindir}/%{name}-rpm-loader
+%attr(755,root,root) %{_libexecdir}/%{name}-rpm-loader
 %attr(755,root,root) %{_sbindir}/fagenrules
 %attr(644,root,root) %{_mandir}/man8/*
 %attr(644,root,root) %{_mandir}/man5/*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -105,12 +105,12 @@ if WITH_RPM
 libfapolicyd_la_SOURCES += \
 	library/rpm-backend.c
 
-bin_PROGRAMS = fapolicyd-rpm-loader
+libexec_PROGRAMS = fapolicyd-rpm-loader
 
 fapolicyd_rpm_loader_SOURCES = \
 	handler/fapolicyd-rpm-loader.c
 
-fapolicyd_CFLAGS += -DBINARYDIR='"$(bindir)"'
+fapolicyd_CFLAGS += -DLIBEXECDIR='"$(libexecdir)"'
 fapolicyd_rpm_loader_CFLAGS = $(fapolicyd_CFLAGS)
 fapolicyd_rpm_loader_LDFLAGS = $(fapolicyd_LDFLAGS)
 fapolicyd_rpm_loader_LDADD = libfapolicyd.la

--- a/src/library/rpm-backend.c
+++ b/src/library/rpm-backend.c
@@ -217,7 +217,7 @@ struct _hash_record {
 
 #define BUFFER_SIZE 4096
 #define MAX_DELIMS 3	// Trustdb has 4 fields - therefore 3 delimiters
-static const char *rpm_loader_path = BINARYDIR "/fapolicyd-rpm-loader";
+static const char *rpm_loader_path = LIBEXECDIR "/fapolicyd-rpm-loader";
 
 static int rpm_load_list(const conf_t *conf)
 {


### PR DESCRIPTION
The loader is an internal helper spawned by the daemon via posix_spawn, not a user-facing executable. Move from `bin_PROGRAMS` to `libexec_PROGRAMS` and rename the `BINARYDIR` define to `LIBEXECDIR`.