### PR TITLE
Minimal change to allow benign dpkg errors

### DIFF
--- a/src/library/deb-backend.c
+++ b/src/library/deb-backend.c
@@ -168,7 +168,7 @@ static int do_deb_load_list(const conf_t *conf)
                              : namenode->name;
       if (hash != NULL) {
         if (add_file_to_backend_by_md5(path, hash, hashtable_ptr, SRC_DEB,
-				   &deb_backend) != 0) {
+				   &deb_backend) < 0) {
 	  rc = 1;
 	  goto out;
 	}

--- a/src/library/md5-backend.c
+++ b/src/library/md5-backend.c
@@ -53,6 +53,10 @@
  * While MD5 is considered broken, this is still some effort.
  * This function would compute a sha256 and file size on the attackers
  * crafted file so they do not secure this backend.
+ *
+ * Returns 0 when the file was added, 1 when the file was skipped
+ * (benign per-file condition), and -1 on a fatal error that leaves
+ * the backend snapshot unusable.
  */
 int add_file_to_backend_by_md5(const char *path, const char *expected_md5,
 			       struct _hash_record **hashtable,
@@ -145,7 +149,7 @@ int add_file_to_backend_by_md5(const char *path, const char *expected_md5,
 				    "dprintf failed writing %s to memfd (%s)",
 				    path, strerror(errno));
 				free((void *)data);
-				return 1;
+				return -1;
 			}
 		}
 		free((void *)data);


### PR DESCRIPTION
This change allows errors to be passed through as either benign or fatal, this is in response to #418 